### PR TITLE
Add storybook story to layer component

### DIFF
--- a/apps/docs/.storybook/global-styles.css
+++ b/apps/docs/.storybook/global-styles.css
@@ -1,0 +1,5 @@
+.example-layer-test-component {
+  padding: 1rem;
+  background: var(--r-layer);
+  color: var(--r-text-primary, #161616);
+}

--- a/apps/docs/.storybook/main.ts
+++ b/apps/docs/.storybook/main.ts
@@ -1,13 +1,14 @@
 import type { StorybookConfig } from '@storybook/react-vite'
 
 import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
 
 /**
  * This function is used to resolve the absolute path of a package.
  * It is needed in projects that use Yarn PnP or are set up within a monorepo.
  */
 function getAbsolutePath(value: string): string {
-  return dirname(require.resolve(join(value, 'package.json')))
+  return dirname(fileURLToPath(import.meta.resolve(join(value, 'package.json'))))
 }
 
 const config: StorybookConfig = {
@@ -15,7 +16,6 @@ const config: StorybookConfig = {
 
   addons: [
     getAbsolutePath('@storybook/addon-essentials'),
-    getAbsolutePath('@chromatic-com/storybook'),
     getAbsolutePath('@storybook/addon-interactions'),
     getAbsolutePath('@storybook/addon-mdx-gfm'),
   ],

--- a/apps/docs/.storybook/preview.ts
+++ b/apps/docs/.storybook/preview.ts
@@ -1,5 +1,6 @@
 import type { Preview } from '@storybook/react'
 import '@ror/styles/css/index.css'
+import './global-styles.css'
 
 const preview: Preview = {
   parameters: {

--- a/apps/docs/.storybook/templates/annotation/annotation.css
+++ b/apps/docs/.storybook/templates/annotation/annotation.css
@@ -1,0 +1,73 @@
+.ror-sb-annotation {
+  --annotation-border-color: #009d9a;
+  --annotation-color: #009d9a;
+  --annotation-background: #f6f2ff;
+  position: relative;
+  border: 1px dashed var(--annotation-border-color);
+}
+
+.ror-sb-annotation .ror-sb-annotation {
+  margin-block-start: 2rem;
+}
+
+.ror-sb-annotation__content > .ror-sb-annotation:first-child {
+  margin-block-start: 0;
+}
+
+.ror-sb-annotation__icon {
+  width: 0.875rem;
+  height: 0.875rem;
+  color: currentColor;
+}
+
+.ror-sb-annotation__label {
+  font-family: var(--r-font-family-sans);
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1.33;
+  letter-spacing: 0.32px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem;
+  column-gap: 0.5rem;
+  background-color: var(--annotation-background);
+  color: var(--annotation-color);
+}
+
+.ror-sb-annotation__label > :first-child {
+  flex-shrink: 0;
+}
+
+.ror-sb-annotation__label a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.ror-sb-annotation__content {
+  padding: 1rem;
+}
+
+/**
+* The different properties should have the following color scale:
+* - Border color: 500
+* - Text color: 800
+* - Background color: 300
+*/
+
+.ror-sb-annotation--layer {
+  --annotation-border-color: #b992fb;
+  --annotation-color: #544076;
+  --annotation-background: #d8c6fd;
+}
+
+.ror-sb-annotation--deprecation-notice {
+  --annotation-border-color: #fa4d56;
+  --annotation-color: #750e13;
+  --annotation-background: #fff1f1;
+}
+
+.ror-sb-annotation--experimental {
+  --annotation-border-color: #009d9a;
+  --annotation-color: #004144;
+  --annotation-background: #d9fbfb;
+}

--- a/apps/docs/.storybook/templates/annotation/annotation.css
+++ b/apps/docs/.storybook/templates/annotation/annotation.css
@@ -61,13 +61,13 @@
 }
 
 .ror-sb-annotation--deprecation-notice {
-  --annotation-border-color: #fa4d56;
-  --annotation-color: #750e13;
-  --annotation-background: #fff1f1;
+  --annotation-border-color: #fc8083;
+  --annotation-color: #773638;
+  --annotation-background: #ffbebc;
 }
 
 .ror-sb-annotation--experimental {
-  --annotation-border-color: #009d9a;
-  --annotation-color: #004144;
-  --annotation-background: #d9fbfb;
+  --annotation-border-color: #e98d61;
+  --annotation-color: #6d3d26;
+  --annotation-background: #f4c3ac;
 }

--- a/apps/docs/.storybook/templates/annotation/annotation.tsx
+++ b/apps/docs/.storybook/templates/annotation/annotation.tsx
@@ -1,0 +1,62 @@
+import { Layers, OctagonAlert, FlaskConical } from 'lucide-react'
+import { ReactNode } from 'react'
+import { clsx } from 'clsx'
+
+import './annotation.css'
+
+const icons = {
+  'deprecation-notice': {
+    icon: OctagonAlert,
+    label: 'Deprecated',
+  },
+  layer: {
+    icon: Layers,
+    label: 'Layer',
+  },
+  experimental: {
+    icon: FlaskConical,
+    label: 'Experimental',
+  },
+}
+
+interface AnnotationProps {
+  /**
+   * Optional class to be passed to the container node
+   */
+  className?: string
+  /**
+   * The type of annotation
+   */
+  type: keyof typeof icons
+  /**
+   * Provide a custom text be displayed in the annotation label, otherwise it uses a default label for the different types
+   */
+  text?: string
+  /**
+   * The content to be displayed in the annotation body
+   */
+  children: ReactNode
+}
+
+/**
+ * Annotation can be used to signify some important context surrounding a component
+ * It can be used to mark components as deprecated, experimental, or that they change depending on layer
+ */
+export function Annotation({ className, type, text, children }: AnnotationProps) {
+  const Icon = icons[type].icon
+  const label = text ?? icons[type].label
+
+  const classes = clsx(className, 'ror-sb-annotation', {
+    [`ror-sb-annotation--${type}`]: true,
+  })
+
+  return (
+    <div className={classes}>
+      <div className='ror-sb-annotation__label'>
+        <Icon className='ror-sb-annotation__icon' />
+        {label}
+      </div>
+      <div className='ror-sb-annotation__content'>{children}</div>
+    </div>
+  )
+}

--- a/apps/docs/.storybook/templates/annotation/index.ts
+++ b/apps/docs/.storybook/templates/annotation/index.ts
@@ -1,0 +1,1 @@
+export { Annotation } from './annotation'

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -10,8 +10,9 @@
     "clean": "rm -rf storybook-static && rm -rf .turbo && rm -rf node_modules"
   },
   "dependencies": {
-    "@ror/styles": "*",
     "@ror/react": "*",
+    "@ror/styles": "*",
+    "clsx": "2.1.1",
     "lucide-react": "0.475.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/apps/docs/stories/CodeSnippet.stories.tsx
+++ b/apps/docs/stories/CodeSnippet.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { CodeSnippet } from '@ror/react/src/components/code-snippet'
 import { TooltipProvider } from '@ror/react/components/tooltip'
+import { Annotation } from '../.storybook/templates/annotation'
+import { Layer } from '@ror/react/src/components/layer'
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta = {
@@ -66,4 +68,26 @@ export const Multi: Story = {
         "@babel/runtime": "^7.10.0",
         "@commitlint/cli": "^8.3.5",`,
   },
+}
+
+export const WithLayer: Story = {
+  args: {
+    type: 'inline',
+    children: 'node -v',
+  },
+  render: (args) => (
+    <Annotation type='layer' text='Layer 0'>
+      <CodeSnippet {...args} />
+      <Annotation type='layer' text='Layer 1'>
+        <Layer level={1}>
+          <CodeSnippet {...args} />
+          <Annotation type='layer' text='Layer 2'>
+            <Layer level={2}>
+              <CodeSnippet {...args} />
+            </Layer>
+          </Annotation>
+        </Layer>
+      </Annotation>
+    </Annotation>
+  ),
 }

--- a/apps/docs/stories/Layer.stories.tsx
+++ b/apps/docs/stories/Layer.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Layer, LayerProps } from '@ror/react/src/components/layer'
+import { Fragment, type ComponentType } from 'react'
+import { Annotation } from '../.storybook/templates/annotation'
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta = {
+  title: 'ui/Layer',
+  component: Layer as ComponentType<LayerProps>,
+  parameters: {
+    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
+    layout: 'centered',
+  },
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ['autodocs'],
+  // Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
+  args: {
+    level: 0,
+  },
+  argTypes: {
+    level: {
+      type: 'string',
+      description:
+        'Which layer to represent the tile on. See referencing docs on Layer model on https://carbondesignsystem.com/elements/color/usage/#layering-tokens',
+      options: [0, 1, 2],
+      control: 'inline-radio',
+    },
+  },
+} satisfies Meta<typeof Layer>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function TestComponent() {
+  return <div className='example-layer-test-component'>Test component</div>
+}
+
+export const Default: Story = {
+  render: () => (
+    <Fragment>
+      <Annotation type='layer' text='Layer 0'>
+        <TestComponent />
+        <Layer level={1}>
+          <Annotation type='layer' text='Layer 1'>
+            <TestComponent />
+            <Layer level={2}>
+              <Annotation type='layer' text='Layer 2'>
+                <TestComponent />
+              </Annotation>
+            </Layer>
+          </Annotation>
+        </Layer>
+      </Annotation>
+    </Fragment>
+  ),
+}
+
+export const CustomLevel: Story = {
+  args: {
+    level: 2,
+  },
+  render: (args) => (
+    <Layer {...args}>
+      <TestComponent />
+    </Layer>
+  ),
+}

--- a/apps/docs/stories/Table.stories.tsx
+++ b/apps/docs/stories/Table.stories.tsx
@@ -9,8 +9,8 @@ import {
   TableBody,
   TableCell,
   TableTitle,
+  TableSubtitle,
 } from '@ror/react/src/components/table/index'
-import { TableSubtitle } from '@ror/react'
 import { SortDirection } from '@ror/react/utils/sorting'
 import { MouseEvent } from 'react'
 

--- a/apps/docs/tsconfig.app.json
+++ b/apps/docs/tsconfig.app.json
@@ -20,5 +20,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite-env.d.ts", "stories"]
+  "include": ["vite-env.d.ts", "stories", ".storybook/templates"]
 }

--- a/apps/web/app/clusters/[id]/metadata-card.tsx
+++ b/apps/web/app/clusters/[id]/metadata-card.tsx
@@ -25,7 +25,7 @@ export function ClusterMetadataCard({ cluster, className }: ClusterMetadataCardP
           <div className='flex flex-col gap-1'>
             <DefinitionTerm>Cluster ID</DefinitionTerm>
             <DefinitionDescription>
-              <Layer layer={1}>
+              <Layer level={1}>
                 <CodeSnippet type='inline'>{clusterId}</CodeSnippet>
               </Layer>
             </DefinitionDescription>

--- a/apps/web/app/clusters/[id]/tools-card.tsx
+++ b/apps/web/app/clusters/[id]/tools-card.tsx
@@ -15,7 +15,7 @@ export function ClusterToolsCard({ cluster, user }: { cluster: Cluster; user: Us
   return (
     <Tile className='p-5 col-span-2'>
       <h3 className='text-base pb-3 mb-5 border-b border-b-(--r-border-subtle)'>Tools</h3>
-      <Layer layer={1}>
+      <Layer level={1}>
         <Stack gap={5} className='max-w-full'>
           <div>
             <h4 className='text-sm text-secondary font-medium mb-2'>ROR CLI</h4>

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -59,11 +59,11 @@ export default async function ProfilePage() {
             </DefinitionList>
             <hr className='my-4' />
             <h3 className='font-semibold text-sm mb-2'>Your access token</h3>
-            <Layer layer={1}>
+            <Layer level={1}>
               <CodeSnippet type='single'>{session.accessToken}</CodeSnippet>
             </Layer>
             <h3 className='font-semibold text-sm mb-2 mt-4'>Your access token (with Bearer)</h3>
-            <Layer layer={1}>
+            <Layer level={1}>
               <CodeSnippet type='single'>{`Bearer ${session.accessToken}`}</CodeSnippet>
             </Layer>
           </Tile>

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       "dependencies": {
         "@ror/react": "*",
         "@ror/styles": "*",
+        "clsx": "2.1.1",
         "lucide-react": "0.475.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"

--- a/packages/react/src/components/layer.tsx
+++ b/packages/react/src/components/layer.tsx
@@ -3,12 +3,12 @@ import type { ReactNode } from 'react'
 import { clsx } from 'clsx'
 import { MAX_LEVEL, MIN_LEVEL, type LayerLevel, levels } from '../utils/layer'
 
-interface LayerProps {
+export interface LayerProps {
   /**
    * Layering level tokens - 0, 1, 2
    * @default 0
    */
-  layer?: LayerLevel
+  level?: LayerLevel
 
   /**
    * Children to be rendered within the layer.
@@ -23,8 +23,8 @@ interface LayerProps {
   asChild?: boolean
 }
 
-export function Layer({ layer = 0, asChild = false, children }: LayerProps) {
-  const value = Math.max(MIN_LEVEL, Math.min(layer, MAX_LEVEL))
+export function Layer({ level = 0, asChild = false, children }: LayerProps) {
+  const value = Math.max(MIN_LEVEL, Math.min(level, MAX_LEVEL))
   const Comp = asChild ? Slot : 'div'
   const layerName = `r-layer--${levels[value]}`
   const classes = clsx({

--- a/packages/styles/scss/css-variables/variables.scss
+++ b/packages/styles/scss/css-variables/variables.scss
@@ -31,13 +31,13 @@
 
   /// Layer
   @include light-dark('layer-01', rgb-color('neutral', '100'), rgb-color('neutral', '900'));
-  @include light-dark('layer-02', rgb-color('neutral', '200'), rgb-color('neutral', '800'));
-  @include light-dark('layer-03', rgb-color('neutral', '100'), rgb-color('neutral', '700'));
+  @include light-dark('layer-02', cv.get-var('color-white'), rgb-color('neutral', '800'));
+  @include light-dark('layer-03', rgb-color('neutral', '200'), rgb-color('neutral', '700'));
   @include light-dark('layer-hover-01', rgb-color('neutral', '200'), rgb-color('neutral', '800'));
-  @include light-dark('layer-hover-02', rgb-color('neutral', '300'), rgb-color('neutral', '700'));
+  @include light-dark('layer-hover-02', rgb-color('neutral', '200'), rgb-color('neutral', '700'));
   @include light-dark('layer-hover-03', rgb-color('neutral', '200'), rgb-color('neutral', '600'));
   @include light-dark('layer-active-01', rgb-color('neutral', '300'), rgb-color('neutral', '700'));
-  @include light-dark('layer-active-02', rgb-color('neutral', '400'), rgb-color('neutral', '600'));
+  @include light-dark('layer-active-02', rgb-color('neutral', '300'), rgb-color('neutral', '600'));
   @include light-dark('layer-active-03', rgb-color('neutral', '300'), rgb-color('neutral', '500'));
   @include light-dark('layer-selected-01', rgb-color('neutral', '200'), rgb-color('neutral', '800'));
   @include light-dark('layer-selected-02', rgb-color('neutral', '200'), rgb-color('neutral', '700'));

--- a/packages/styles/scss/css-variables/variables.scss
+++ b/packages/styles/scss/css-variables/variables.scss
@@ -35,27 +35,27 @@
   @include light-dark('layer-03', rgb-color('neutral', '200'), rgb-color('neutral', '700'));
   @include light-dark('layer-hover-01', rgb-color('neutral', '200'), rgb-color('neutral', '800'));
   @include light-dark('layer-hover-02', rgb-color('neutral', '200'), rgb-color('neutral', '700'));
-  @include light-dark('layer-hover-03', rgb-color('neutral', '200'), rgb-color('neutral', '600'));
+  @include light-dark('layer-hover-03', rgb-color('neutral', '300'), rgb-color('neutral', '600'));
   @include light-dark('layer-active-01', rgb-color('neutral', '300'), rgb-color('neutral', '700'));
   @include light-dark('layer-active-02', rgb-color('neutral', '300'), rgb-color('neutral', '600'));
-  @include light-dark('layer-active-03', rgb-color('neutral', '300'), rgb-color('neutral', '500'));
+  @include light-dark('layer-active-03', rgb-color('neutral', '400'), rgb-color('neutral', '500'));
   @include light-dark('layer-selected-01', rgb-color('neutral', '200'), rgb-color('neutral', '800'));
   @include light-dark('layer-selected-02', rgb-color('neutral', '200'), rgb-color('neutral', '700'));
-  @include light-dark('layer-selected-03', rgb-color('neutral', '200'), rgb-color('neutral', '600'));
+  @include light-dark('layer-selected-03', rgb-color('neutral', '300'), rgb-color('neutral', '600'));
   @include light-dark('layer-selected-hover-01', rgb-color('neutral', '300'), rgb-color('neutral', '700'));
   @include light-dark('layer-selected-hover-02', rgb-color('neutral', '300'), rgb-color('neutral', '600'));
-  @include light-dark('layer-selected-hover-03', rgb-color('neutral', '300'), rgb-color('neutral', '500'));
+  @include light-dark('layer-selected-hover-03', rgb-color('neutral', '400'), rgb-color('neutral', '500'));
 
   /// Layer Accent - Tertiary background paired with $layer-X
   @include light-dark('layer-accent-01', rgb-color('neutral', '200'), rgb-color('neutral', '800'));
   @include light-dark('layer-accent-02', rgb-color('neutral', '200'), rgb-color('neutral', '700'));
-  @include light-dark('layer-accent-03', rgb-color('neutral', '200'), rgb-color('neutral', '600'));
+  @include light-dark('layer-accent-03', rgb-color('neutral', '300'), rgb-color('neutral', '600'));
   @include light-dark('layer-accent-hover-01', rgb-color('neutral', '300'), rgb-color('neutral', '700'));
   @include light-dark('layer-accent-hover-02', rgb-color('neutral', '300'), rgb-color('neutral', '600'));
-  @include light-dark('layer-accent-hover-03', rgb-color('neutral', '300'), rgb-color('neutral', '500'));
+  @include light-dark('layer-accent-hover-03', rgb-color('neutral', '400'), rgb-color('neutral', '500'));
   @include light-dark('layer-accent-active-01', rgb-color('neutral', '400'), rgb-color('neutral', '700'));
   @include light-dark('layer-accent-active-02', rgb-color('neutral', '400'), rgb-color('neutral', '500'));
-  @include light-dark('layer-accent-active-03', rgb-color('neutral', '400'), rgb-color('neutral', '800'));
+  @include light-dark('layer-accent-active-03', rgb-color('neutral', '500'), rgb-color('neutral', '800'));
 
   /// Borders
   @include light-dark('border-interactive', rgb-color('teal', '600'), rgb-color('teal', '700'));
@@ -135,31 +135,31 @@
 
       /// Layer
       @include light-dark('layer-01', p3-color('neutral', '100'), p3-color('neutral', '900'));
-      @include light-dark('layer-02', p3-color('neutral', '200'), p3-color('neutral', '800'));
-      @include light-dark('layer-03', p3-color('neutral', '100'), p3-color('neutral', '700'));
+      @include light-dark('layer-02', cv.get-var('color-white'), p3-color('neutral', '800'));
+      @include light-dark('layer-03', p3-color('neutral', '200'), p3-color('neutral', '700'));
       @include light-dark('layer-hover-01', p3-color('neutral', '200'), p3-color('neutral', '800'));
-      @include light-dark('layer-hover-02', p3-color('neutral', '300'), p3-color('neutral', '700'));
-      @include light-dark('layer-hover-03', p3-color('neutral', '200'), p3-color('neutral', '600'));
+      @include light-dark('layer-hover-02', p3-color('neutral', '200'), p3-color('neutral', '700'));
+      @include light-dark('layer-hover-03', p3-color('neutral', '300'), p3-color('neutral', '600'));
       @include light-dark('layer-active-01', p3-color('neutral', '300'), p3-color('neutral', '700'));
-      @include light-dark('layer-active-02', p3-color('neutral', '400'), p3-color('neutral', '600'));
-      @include light-dark('layer-active-03', p3-color('neutral', '300'), p3-color('neutral', '500'));
+      @include light-dark('layer-active-02', p3-color('neutral', '300'), p3-color('neutral', '600'));
+      @include light-dark('layer-active-03', p3-color('neutral', '400'), p3-color('neutral', '500'));
       @include light-dark('layer-selected-01', p3-color('neutral', '200'), p3-color('neutral', '800'));
       @include light-dark('layer-selected-02', p3-color('neutral', '200'), p3-color('neutral', '700'));
-      @include light-dark('layer-selected-03', p3-color('neutral', '200'), p3-color('neutral', '600'));
+      @include light-dark('layer-selected-03', p3-color('neutral', '300'), p3-color('neutral', '600'));
       @include light-dark('layer-selected-hover-01', p3-color('neutral', '300'), p3-color('neutral', '700'));
       @include light-dark('layer-selected-hover-02', p3-color('neutral', '300'), p3-color('neutral', '600'));
-      @include light-dark('layer-selected-hover-03', p3-color('neutral', '300'), p3-color('neutral', '500'));
+      @include light-dark('layer-selected-hover-03', p3-color('neutral', '400'), p3-color('neutral', '500'));
 
       /// Layer Accent - Tertiary background paired with $layer-X
       @include light-dark('layer-accent-01', p3-color('neutral', '200'), p3-color('neutral', '800'));
       @include light-dark('layer-accent-02', p3-color('neutral', '200'), p3-color('neutral', '700'));
-      @include light-dark('layer-accent-03', p3-color('neutral', '200'), p3-color('neutral', '600'));
+      @include light-dark('layer-accent-03', p3-color('neutral', '300'), p3-color('neutral', '600'));
       @include light-dark('layer-accent-hover-01', p3-color('neutral', '300'), p3-color('neutral', '700'));
       @include light-dark('layer-accent-hover-02', p3-color('neutral', '300'), p3-color('neutral', '600'));
-      @include light-dark('layer-accent-hover-03', p3-color('neutral', '300'), p3-color('neutral', '500'));
+      @include light-dark('layer-accent-hover-03', p3-color('neutral', '400'), p3-color('neutral', '500'));
       @include light-dark('layer-accent-active-01', p3-color('neutral', '400'), p3-color('neutral', '700'));
       @include light-dark('layer-accent-active-02', p3-color('neutral', '400'), p3-color('neutral', '500'));
-      @include light-dark('layer-accent-active-03', p3-color('neutral', '400'), p3-color('neutral', '800'));
+      @include light-dark('layer-accent-active-03', p3-color('neutral', '500'), p3-color('neutral', '800'));
 
       /// Borders
       /// 00 - Paired with $background


### PR DESCRIPTION
This pull request introduces mainly a Story for the layer component but there are also some other notable changes.

## Changes
- Added a Storybook story for the `Layer` component
- `Layer` prop `layer` has been renamed to `level` as it more easy to understand, e.g. 
```.tsx
<Layer level={1}> 
  ...
</Layer>
```
- Changed the variable of `layer-02` to point to our white color, same as `background` since that corresponds to the same color used by carbon design system.
- Added a `Annotation` component specifically for our design documentation, making it easier to document components that either:
  - Change styles based on the surrounding layer, for instance the `CodeSnippet` component (colored as purple)
  - Mark components as deprecated (colored as red)
  - Mark components as experimental (colored as orange)
-  Updated the `getAbsolutePath` in `.storybook/main.ts` to make use out of more modern alternatives to commonjs