### PR TITLE
feat(styles): add layer cascading rules that are compatible with tailwind

### DIFF
--- a/apps/web/app/globals.scss
+++ b/apps/web/app/globals.scss
@@ -1,12 +1,6 @@
-@use '@ror/styles' with (
-  $css--reset: false
-);
-
-@use '@ror/styles/scss/reset';
+@use '@ror/styles';
 
 @layer base {
-  @include reset.emit-reset-style();
-
   /// This lets the browser know that this websites supports both light and dark modes.
   html,
   html[data-color-scheme='system'] {

--- a/packages/styles/index.scss
+++ b/packages/styles/index.scss
@@ -1,8 +1,11 @@
 // Forward configuration
 @forward 'scss/config';
 
+// Establish layer cascade rules
+@use 'layer-cascade-rules';
+
 // Use CSS variables
-@use 'scss/css-variables/variables.scss';
+@use 'scss/css-variables/variables';
 @use 'scss/layer';
 
 /// Add reset styles (can be overriden with configuration)

--- a/packages/styles/layer-cascade-rules.scss
+++ b/packages/styles/layer-cascade-rules.scss
@@ -1,0 +1,1 @@
+@layer theme, base, components, utilities;

--- a/packages/styles/scss/components/breadcrumb.scss
+++ b/packages/styles/scss/components/breadcrumb.scss
@@ -2,63 +2,65 @@
 @use '../type/styles.scss' as types;
 @use '../utilities/custom-properties.scss' as cv;
 
-.#{c.$prefix}-breadcrumb {
-  box-sizing: border-box;
-  padding: 0;
-  border: 0;
-  margin: 0;
-  font-family: inherit;
-  font-size: 100%;
-  vertical-align: baseline;
-  @include types.type-style('body-01');
-  display: inline;
-}
-
-.#{c.$prefix}-breadcrumb__item {
-  position: relative;
-  display: flex;
-  align-items: center;
-  margin-inline-end: 0.5rem;
-
-  &::after {
-    box-sizing: inherit;
-    color: cv.get-var('text-primary');
-    content: '/';
-    margin-inline-start: 0.5rem;
-  }
-
-  &:last-child,
-  &:last-child::after {
-    margin-inline-end: 0;
-  }
-}
-
-.#{c.$prefix}-breadcrumb__link {
-  padding: 0;
-  border: 0;
-  margin: 0;
-  font-family: inherit;
-  font-size: 100%;
-  vertical-align: baseline;
-  @include types.type-style('body-01');
-  display: inline-flex;
-  color: cv.get-var('text-primary');
-  outline: none;
-  text-decoration: none;
-  transition: color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
-
-  &[href] {
-    color: cv.get-var('link-primary');
-  }
-}
-
-.#{c.$prefix}-breadcrumb--no-trailing-slash .#{c.$prefix}-breadcrumb__item:last-child::after {
-  content: '';
-}
-
-@media (min-width: 42rem) {
+@layer components {
   .#{c.$prefix}-breadcrumb {
+    box-sizing: border-box;
+    padding: 0;
+    border: 0;
+    margin: 0;
+    font-family: inherit;
+    font-size: 100%;
+    vertical-align: baseline;
+    @include types.type-style('body-01');
+    display: inline;
+  }
+
+  .#{c.$prefix}-breadcrumb__item {
+    position: relative;
     display: flex;
-    flex-wrap: wrap;
+    align-items: center;
+    margin-inline-end: 0.5rem;
+
+    &::after {
+      box-sizing: inherit;
+      color: cv.get-var('text-primary');
+      content: '/';
+      margin-inline-start: 0.5rem;
+    }
+
+    &:last-child,
+    &:last-child::after {
+      margin-inline-end: 0;
+    }
+  }
+
+  .#{c.$prefix}-breadcrumb__link {
+    padding: 0;
+    border: 0;
+    margin: 0;
+    font-family: inherit;
+    font-size: 100%;
+    vertical-align: baseline;
+    @include types.type-style('body-01');
+    display: inline-flex;
+    color: cv.get-var('text-primary');
+    outline: none;
+    text-decoration: none;
+    transition: color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+
+    &[href] {
+      color: cv.get-var('link-primary');
+    }
+  }
+
+  .#{c.$prefix}-breadcrumb--no-trailing-slash .#{c.$prefix}-breadcrumb__item:last-child::after {
+    content: '';
+  }
+
+  @media (min-width: 42rem) {
+    .#{c.$prefix}-breadcrumb {
+      display: flex;
+      flex-wrap: wrap;
+    }
   }
 }

--- a/packages/styles/scss/components/button.scss
+++ b/packages/styles/scss/components/button.scss
@@ -2,104 +2,106 @@
 @use '../type/styles.scss' as types;
 @use '../utilities/custom-properties.scss' as cv;
 
-.#{c.$prefix}-btn {
-  --btn-height: 2rem;
-  --btn-x-padding: #{cv.get-var('spacing-05')};
-  block-size: var(--btn-height);
-  display: inline-flex;
-  vertical-align: top;
-  align-items: center;
-  justify-content: center;
-  white-space: nowrap;
-  flex-shrink: 0;
-  margin: 0;
-  border-radius: 5px;
-  transition-property: border, background-color, color, opacity;
-  transition-duration: cv.get-var('speed-highlight-fadeout', '150ms');
-  user-select: none;
-  app-region: no-drag;
-  position: relative;
-  border: 0.5px solid cv.get-var('button-primary-border');
-  background-color: cv.get-var('button-primary');
-  color: cv.get-var('text-on-color');
-  inline-size: max-content;
-  max-inline-size: 20rem;
-  min-inline-size: 2rem;
-  padding: 0 var(--btn-x-padding);
-  cursor: pointer;
-  -webkit-font-smoothing: antialiased;
-  @include types.type-style('body-01');
-}
-
-.#{c.$prefix}-btn--sm {
-  --btn-height: 1.75rem;
-  border-radius: 4px;
-}
-
-.#{c.$prefix}-btn--md {
-  --btn-height: 2rem;
-  padding: 0 1rem;
-  border-radius: 4px;
-}
-
-.#{c.$prefix}-btn--lg {
-  --btn-height: 2.5rem;
-  border-radius: 6px;
-}
-
-.#{c.$prefix}-btn--primary {
-  background: cv.get-var('button-primary');
-  border-color: cv.get-var('button-primary-border');
-  color: cv.get-var('text-on-color');
-
-  &:hover {
-    background: cv.get-var('button-primary-hover');
-    border-color: cv.get-var('button-primary-border-hover');
+@layer components {
+  .#{c.$prefix}-btn {
+    --btn-height: 2rem;
+    --btn-x-padding: #{cv.get-var('spacing-05')};
+    block-size: var(--btn-height);
+    display: inline-flex;
+    vertical-align: top;
+    align-items: center;
+    justify-content: center;
+    white-space: nowrap;
+    flex-shrink: 0;
+    margin: 0;
+    border-radius: 5px;
+    transition-property: border, background-color, color, opacity;
+    transition-duration: cv.get-var('speed-highlight-fadeout', '150ms');
+    user-select: none;
+    app-region: no-drag;
+    position: relative;
+    border: 0.5px solid cv.get-var('button-primary-border');
+    background-color: cv.get-var('button-primary');
+    color: cv.get-var('text-on-color');
+    inline-size: max-content;
+    max-inline-size: 20rem;
+    min-inline-size: 2rem;
+    padding: 0 var(--btn-x-padding);
+    cursor: pointer;
+    -webkit-font-smoothing: antialiased;
+    @include types.type-style('body-01');
   }
 
-  &:active {
-    background: cv.get-var('button-primary-active');
-    border-color: cv.get-var('button-primary-border-active');
+  .#{c.$prefix}-btn--sm {
+    --btn-height: 1.75rem;
+    border-radius: 4px;
   }
-}
 
-.#{c.$prefix}-btn--secondary {
-  background: cv.get-var('button-secondary');
-  border-color: cv.get-var('button-secondary-border');
-  color: cv.get-var('text-on-color');
-}
+  .#{c.$prefix}-btn--md {
+    --btn-height: 2rem;
+    padding: 0 1rem;
+    border-radius: 4px;
+  }
 
-.#{c.$prefix}-btn--tertiary {
-  background: cv.get-var('button-tertiary');
-  border-color: cv.get-var('button-tertiary-border');
-  color: cv.get-var('button-primary');
-}
+  .#{c.$prefix}-btn--lg {
+    --btn-height: 2.5rem;
+    border-radius: 6px;
+  }
 
-.#{c.$prefix}-btn--danger {
-  background: cv.get-var('button-danger');
-  border-color: cv.get-var('button-danger-border');
-  color: cv.get-var('text-on-color');
-}
+  .#{c.$prefix}-btn--primary {
+    background: cv.get-var('button-primary');
+    border-color: cv.get-var('button-primary-border');
+    color: cv.get-var('text-on-color');
 
-.#{c.$prefix}-btn--ghost {
-  border-color: transparent;
-  background-color: transparent;
-}
+    &:hover {
+      background: cv.get-var('button-primary-hover');
+      border-color: cv.get-var('button-primary-border-hover');
+    }
 
-.#{c.$prefix}-btn--ghost:hover {
-  background: cv.get-var('background-hover');
-}
+    &:active {
+      background: cv.get-var('button-primary-active');
+      border-color: cv.get-var('button-primary-border-active');
+    }
+  }
 
-.#{c.$prefix}-btn--icon-only {
-  justify-content: center;
-  padding: 0;
-  inline-size: var(--btn-height);
-  block-size: var(--btn-height);
-}
+  .#{c.$prefix}-btn--secondary {
+    background: cv.get-var('button-secondary');
+    border-color: cv.get-var('button-secondary-border');
+    color: cv.get-var('text-on-color');
+  }
 
-.#{c.$prefix}-btn--icon-only svg {
-  min-inline-size: 1rem;
-  inline-size: 1rem;
-  block-size: 1rem;
-  color: cv.get-var('icon-primary');
+  .#{c.$prefix}-btn--tertiary {
+    background: cv.get-var('button-tertiary');
+    border-color: cv.get-var('button-tertiary-border');
+    color: cv.get-var('button-primary');
+  }
+
+  .#{c.$prefix}-btn--danger {
+    background: cv.get-var('button-danger');
+    border-color: cv.get-var('button-danger-border');
+    color: cv.get-var('text-on-color');
+  }
+
+  .#{c.$prefix}-btn--ghost {
+    border-color: transparent;
+    background-color: transparent;
+  }
+
+  .#{c.$prefix}-btn--ghost:hover {
+    background: cv.get-var('background-hover');
+  }
+
+  .#{c.$prefix}-btn--icon-only {
+    justify-content: center;
+    padding: 0;
+    inline-size: var(--btn-height);
+    block-size: var(--btn-height);
+  }
+
+  .#{c.$prefix}-btn--icon-only svg {
+    min-inline-size: 1rem;
+    inline-size: 1rem;
+    block-size: 1rem;
+    color: cv.get-var('icon-primary');
+  }
 }

--- a/packages/styles/scss/components/code-snippet.scss
+++ b/packages/styles/scss/components/code-snippet.scss
@@ -2,116 +2,118 @@
 @use '../utilities/custom-properties.scss' as cv;
 @use '../type/styles.scss' as type;
 
-.#{$prefix}-code-snippet {
-  --code-snippet-multi-max-height: 16rem;
-  background-color: cv.get-var('layer');
-  color: cv.get-var('text-primary');
-  position: relative;
-}
+@layer components {
+  .#{$prefix}-code-snippet {
+    --code-snippet-multi-max-height: 16rem;
+    background-color: cv.get-var('layer');
+    color: cv.get-var('text-primary');
+    position: relative;
+  }
 
-/// Base
-.#{$prefix}-code-snippet code {
-  @include type.type-style('code-01');
-}
+  /// Base
+  .#{$prefix}-code-snippet code {
+    @include type.type-style('code-01');
+  }
 
-.#{$prefix}-code-snippet pre {
-  margin: 0;
-}
+  .#{$prefix}-code-snippet pre {
+    margin: 0;
+  }
 
-.#{$prefix}-code-snippet__overflow-indicator--right {
-  order: 2;
-  background-image: linear-gradient(to right, transparent, cv.get-var('layer'));
-  margin-inline-start: -1rem;
-}
+  .#{$prefix}-code-snippet__overflow-indicator--right {
+    order: 2;
+    background-image: linear-gradient(to right, transparent, cv.get-var('layer'));
+    margin-inline-start: -1rem;
+  }
 
-.#{$prefix}-code-snippet__overflow-indicator--left,
-.#{$prefix}-code-snippet__overflow-indicator--right {
-  z-index: 1;
-  flex: 1 0 auto;
-  inline-size: 1rem;
-}
+  .#{$prefix}-code-snippet__overflow-indicator--left,
+  .#{$prefix}-code-snippet__overflow-indicator--right {
+    z-index: 1;
+    flex: 1 0 auto;
+    inline-size: 1rem;
+  }
 
-.#{$prefix}-code-snippet__copy-btn {
-  position: absolute;
-  inset-block-start: 0;
-  inset-inline-end: 0;
-  border-radius: 0;
-}
+  .#{$prefix}-code-snippet__copy-btn {
+    position: absolute;
+    inset-block-start: 0;
+    inset-inline-end: 0;
+    border-radius: 0;
+  }
 
-/// Inline
-.#{$prefix}-code-snippet--inline {
-  position: relative;
-  display: inline;
-  padding: 0;
-  border: 1px solid rgba(0, 0, 0, 0);
-  border-radius: 4px;
-  cursor: pointer;
-}
+  /// Inline
+  .#{$prefix}-code-snippet--inline {
+    position: relative;
+    display: inline;
+    padding: 0;
+    border: 1px solid rgba(0, 0, 0, 0);
+    border-radius: 4px;
+    cursor: pointer;
+  }
 
-.#{$prefix}-code-snippet--inline.#{$prefix}-btn {
-  block-size: 1.25rem;
-  inline-size: initial;
-  max-inline-size: unset;
-  min-block-size: 1.25rem;
-  padding-inline: 0;
-}
+  .#{$prefix}-code-snippet--inline.#{$prefix}-btn {
+    block-size: 1.25rem;
+    inline-size: initial;
+    max-inline-size: unset;
+    min-block-size: 1.25rem;
+    padding-inline: 0;
+  }
 
-.#{$prefix}-code-snippet--inline code {
-  padding-inline: 0.5rem;
-}
+  .#{$prefix}-code-snippet--inline code {
+    padding-inline: 0.5rem;
+  }
 
-/// Single
-.#{$prefix}-code-snippet--single {
-  position: relative;
-  inline-size: 100%;
-  max-inline-size: 48rem;
-  display: flex;
-  align-items: center;
-  block-size: 2.5rem;
-  padding-inline-end: 2.5rem;
-  border-radius: 0.125rem;
-}
+  /// Single
+  .#{$prefix}-code-snippet--single {
+    position: relative;
+    inline-size: 100%;
+    max-inline-size: 48rem;
+    display: flex;
+    align-items: center;
+    block-size: 2.5rem;
+    padding-inline-end: 2.5rem;
+    border-radius: 0.125rem;
+  }
 
-.#{$prefix}-code-snippet--single .#{$prefix}-code-snippet__container {
-  position: relative;
-  display: flex;
-  align-items: center;
-  block-size: 100%;
-  overflow-x: auto;
-  padding-inline-start: 1rem;
-  scrollbar-width: none;
-}
+  .#{$prefix}-code-snippet--single .#{$prefix}-code-snippet__container {
+    position: relative;
+    display: flex;
+    align-items: center;
+    block-size: 100%;
+    overflow-x: auto;
+    padding-inline-start: 1rem;
+    scrollbar-width: none;
+  }
 
-.#{$prefix}-code-snippet--single .#{$prefix}-code-snippet__overflow-indicator--right {
-  inset-inline-end: 2.5rem;
-}
+  .#{$prefix}-code-snippet--single .#{$prefix}-code-snippet__overflow-indicator--right {
+    inset-inline-end: 2.5rem;
+  }
 
-.#{$prefix}-code-snippet--single .#{$prefix}-code-snippet__overflow-indicator--right,
-.#{$prefix}-code-snippet--single .#{$prefix}-code-snippet__overflow-indicator--left {
-  position: absolute;
-  block-size: calc(100% - 0.25rem);
-  inline-size: 2rem;
-}
+  .#{$prefix}-code-snippet--single .#{$prefix}-code-snippet__overflow-indicator--right,
+  .#{$prefix}-code-snippet--single .#{$prefix}-code-snippet__overflow-indicator--left {
+    position: absolute;
+    block-size: calc(100% - 0.25rem);
+    inline-size: 2rem;
+  }
 
-.#{$prefix}-code-snippet--single pre,
-.#{$prefix}-code-snippet--inline code {
-  white-space: pre;
-}
+  .#{$prefix}-code-snippet--single pre,
+  .#{$prefix}-code-snippet--inline code {
+    white-space: pre;
+  }
 
-.#{$prefix}-code-snippet--single pre {
-  padding-inline-end: 0.5rem;
-}
+  .#{$prefix}-code-snippet--single pre {
+    padding-inline-end: 0.5rem;
+  }
 
-/// Multi
-.#{$prefix}-code-snippet--multi {
-  padding: 1rem;
-}
+  /// Multi
+  .#{$prefix}-code-snippet--multi {
+    padding: 1rem;
+  }
 
-.#{$prefix}-code-snippet--multi .#{$prefix}-code-snippet__container {
-  position: relative;
-  order: 1;
-  overflow: auto;
-  max-block-size: 100%;
-  min-block-size: 100%;
-  max-height: var(--code-snippet-multi-max-height);
+  .#{$prefix}-code-snippet--multi .#{$prefix}-code-snippet__container {
+    position: relative;
+    order: 1;
+    overflow: auto;
+    max-block-size: 100%;
+    min-block-size: 100%;
+    max-height: var(--code-snippet-multi-max-height);
+  }
 }

--- a/packages/styles/scss/components/copy-button.scss
+++ b/packages/styles/scss/components/copy-button.scss
@@ -1,21 +1,23 @@
 @use '../config.scss' as *;
 @use '../utilities/custom-properties.scss' as cv;
 
-.#{$prefix}-copy-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  border: none;
-  background-color: cv.get-var('layer');
-  cursor: pointer;
-  outline: none;
+@layer components {
+  .#{$prefix}-copy-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: none;
+    background-color: cv.get-var('layer');
+    cursor: pointer;
+    outline: none;
 
-  &:hover {
-    background-color: cv.get-var('layer-hover');
-  }
+    &:hover {
+      background-color: cv.get-var('layer-hover');
+    }
 
-  &:active {
-    background-color: cv.get-var('layer-active');
+    &:active {
+      background-color: cv.get-var('layer-active');
+    }
   }
 }

--- a/packages/styles/scss/components/definition-list.scss
+++ b/packages/styles/scss/components/definition-list.scss
@@ -2,32 +2,34 @@
 @use '../type/styles.scss' as *;
 @use '../utilities/custom-properties.scss' as cv;
 
-.#{$prefix}-dl {
-  margin: 0;
-  inline-size: 100%;
+@layer components {
+  .#{$prefix}-dl {
+    margin: 0;
+    inline-size: 100%;
 
-  &--horizontal {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    row-gap: cv.get-var('spacing-04');
-    column-gap: cv.get-var('spacing-02');
+    &--horizontal {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      row-gap: cv.get-var('spacing-04');
+      column-gap: cv.get-var('spacing-02');
+    }
+
+    &--vertical {
+      display: flex;
+      flex-direction: column;
+      row-gap: cv.get-var('spacing-03');
+    }
   }
 
-  &--vertical {
-    display: flex;
-    flex-direction: column;
-    row-gap: cv.get-var('spacing-03');
+  .#{$prefix}-dl__term {
+    margin: 0;
+    @include type-style('heading-01');
+    color: cv.get-var('text-secondary');
   }
-}
 
-.#{$prefix}-dl__term {
-  margin: 0;
-  @include type-style('heading-01');
-  color: cv.get-var('text-secondary');
-}
-
-.#{$prefix}-dl__description {
-  font-style: normal;
-  margin: 0;
-  @include type-style('body-01');
+  .#{$prefix}-dl__description {
+    font-style: normal;
+    margin: 0;
+    @include type-style('body-01');
+  }
 }

--- a/packages/styles/scss/components/icon-indicator.scss
+++ b/packages/styles/scss/components/icon-indicator.scss
@@ -4,60 +4,62 @@
 @use '../type/styles.scss' as type;
 @use '../type/font-family.scss' as ff;
 
-.#{$prefix}-icon-indicator {
-  --icon-color: #{get-var('icon-secondary')};
-  --icon-size: #{convert.to-rem(20px)};
-  display: flex;
-  align-items: center;
-  color: get-var('text-primary');
+@layer components {
+  .#{$prefix}-icon-indicator {
+    --icon-color: #{get-var('icon-secondary')};
+    --icon-size: #{convert.to-rem(20px)};
+    display: flex;
+    align-items: center;
+    color: get-var('text-primary');
 
-  &__icon {
-    align-self: center;
-    margin-inline-end: 0.5rem;
-    block-size: var(--icon-size);
-    inline-size: var(--icon-size);
-    color: var(--icon-color);
+    &__icon {
+      align-self: center;
+      margin-inline-end: 0.5rem;
+      block-size: var(--icon-size);
+      inline-size: var(--icon-size);
+      color: var(--icon-color);
+    }
+
+    &__label {
+      display: inline-flex;
+      transform: translateY(1px);
+    }
   }
 
-  &__label {
-    display: inline-flex;
-    transform: translateY(1px);
+  .#{$prefix}-icon-indicator--md {
+    --icon-size: #{convert.to-rem(20px)};
+    @include type.type-style('body-01');
   }
-}
 
-.#{$prefix}-icon-indicator--md {
-  --icon-size: #{convert.to-rem(20px)};
-  @include type.type-style('body-01');
-}
+  .#{$prefix}-icon-indicator--lg {
+    --icon-size: #{convert.to-rem(24px)};
+    @include type.type-style('body-02');
+  }
 
-.#{$prefix}-icon-indicator--lg {
-  --icon-size: #{convert.to-rem(24px)};
-  @include type.type-style('body-02');
-}
+  .#{$prefix}-icon-indicator--failed {
+    --icon-color: #{get-var('support-error')};
+  }
 
-.#{$prefix}-icon-indicator--failed {
-  --icon-color: #{get-var('support-error')};
-}
+  .#{$prefix}-icon-indicator--caution-major {
+    --icon-color: #{get-var('support-caution-major')};
+  }
 
-.#{$prefix}-icon-indicator--caution-major {
-  --icon-color: #{get-var('support-caution-major')};
-}
+  .#{$prefix}-icon-indicator--caution-minor {
+    --icon-color: #{get-var('support-caution-minor')};
+  }
 
-.#{$prefix}-icon-indicator--caution-minor {
-  --icon-color: #{get-var('support-caution-minor')};
-}
+  .#{$prefix}-icon-indicator--undefined {
+    --icon-color: #{get-var('support-caution-undefined')};
+  }
 
-.#{$prefix}-icon-indicator--undefined {
-  --icon-color: #{get-var('support-caution-undefined')};
-}
+  .#{$prefix}-icon-indicator--succeeded {
+    --icon-color: #{get-var('support-success')};
+  }
 
-.#{$prefix}-icon-indicator--succeeded {
-  --icon-color: #{get-var('support-success')};
-}
-
-.#{$prefix}-icon-indicator--normal,
-.#{$prefix}-icon-indicator--in-progress,
-.#{$prefix}-icon-indicator--incomplete,
-.#{$prefix}-icon-indicator--informative {
-  --icon-color: #{get-var('support-info')};
+  .#{$prefix}-icon-indicator--normal,
+  .#{$prefix}-icon-indicator--in-progress,
+  .#{$prefix}-icon-indicator--incomplete,
+  .#{$prefix}-icon-indicator--informative {
+    --icon-color: #{get-var('support-info')};
+  }
 }

--- a/packages/styles/scss/components/metrics-wheel.scss
+++ b/packages/styles/scss/components/metrics-wheel.scss
@@ -13,35 +13,37 @@ $metric-colors: (
   'emerald': cv.get-var('metrics-emerald'),
 );
 
-.#{c.$prefix}-metrics-wheel {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+@layer components {
+  .#{c.$prefix}-metrics-wheel {
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
-  svg {
-    width: 9rem;
-    height: 9rem;
-  }
+    svg {
+      width: 9rem;
+      height: 9rem;
+    }
 
-  &__circle {
-    stroke-width: 10;
-    stroke-linecap: round;
-    fill: transparent;
-    transition: stroke-dashoffset 0.5s ease-in-out;
+    &__circle {
+      stroke-width: 10;
+      stroke-linecap: round;
+      fill: transparent;
+      transition: stroke-dashoffset 0.5s ease-in-out;
 
-    @each $color, $value in $metric-colors {
-      &--#{'' + $color} {
-        stroke: $value;
+      @each $color, $value in $metric-colors {
+        &--#{'' + $color} {
+          stroke: $value;
+        }
       }
     }
-  }
 
-  &__label {
-    color: get-var('text-primary');
-    font-weight: bold;
-    text-anchor: middle;
-    dominant-baseline: middle;
-    font-size: 0.875rem;
-    letter-spacing: 0.16px;
+    &__label {
+      color: get-var('text-primary');
+      font-weight: bold;
+      text-anchor: middle;
+      dominant-baseline: middle;
+      font-size: 0.875rem;
+      letter-spacing: 0.16px;
+    }
   }
 }

--- a/packages/styles/scss/components/stack.scss
+++ b/packages/styles/scss/components/stack.scss
@@ -3,32 +3,34 @@
 @use '../utilities/convert.scss';
 @use '../spacing.scss';
 
-.#{$prefix}-stack {
-  &--vertical {
-    display: grid;
-    grid-auto-flow: row;
-    row-gap: get-var('stack-gap', 0);
-  }
-
-  &--horizontal {
-    display: inline-grid;
-    column-gap: get-var('stack-gap', 0);
-    grid-auto-flow: column;
-  }
-
-  /// Hack to prevent children from extending beyond the parent width
-  /// @see issue https://github.com/carbon-design-system/carbon/issues/18419
-  & > * {
-    min-inline-size: 0;
-  }
-
-  $index: 1;
-
-  @each $step, $value in spacing.$spacing {
-    &--scale-#{$index} {
-      @include declaration('stack-gap', $value);
+@layer components {
+  .#{$prefix}-stack {
+    &--vertical {
+      display: grid;
+      grid-auto-flow: row;
+      row-gap: get-var('stack-gap', 0);
     }
 
-    $index: $index + 1;
+    &--horizontal {
+      display: inline-grid;
+      column-gap: get-var('stack-gap', 0);
+      grid-auto-flow: column;
+    }
+
+    /// Hack to prevent children from extending beyond the parent width
+    /// @see issue https://github.com/carbon-design-system/carbon/issues/18419
+    & > * {
+      min-inline-size: 0;
+    }
+
+    $index: 1;
+
+    @each $step, $value in spacing.$spacing {
+      &--scale-#{$index} {
+        @include declaration('stack-gap', $value);
+      }
+
+      $index: $index + 1;
+    }
   }
 }

--- a/packages/styles/scss/components/table.scss
+++ b/packages/styles/scss/components/table.scss
@@ -4,242 +4,243 @@
 @use '../type/styles.scss' as type;
 @use '../type/font-family.scss' as ff;
 
-/* Default table styles */
-
-.#{c.$prefix}-table-container {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-areas:
-    'title actions'
-    'subtitle subtitle'
-    'filter filter'
-    'table table'
-    'footer footer';
-  column-gap: get-var('spacing-03');
-}
-
-.#{c.$prefix}-table__title {
-  @include type.type-style('heading-03');
-  margin: 0;
-  color: get-var('text-primary');
-  grid-area: title;
-  align-self: center;
-}
-
-.#{c.$prefix}-table__subtitle {
-  margin: 0;
-  @include type.type-style('body-01');
-  color: get-var('text-secondary');
-  grid-area: subtitle;
-}
-
-.#{c.$prefix}-table__actions {
-  display: flex;
-  column-gap: get-var('spacing-03');
-  align-items: center;
-  grid-area: actions;
-  justify-self: end;
-}
-
-.#{c.$prefix}-table__divider {
-  width: 100%;
-  height: 1px;
-  background-color: get-var('border-subtle');
-  grid-area: divider;
-  margin-block-start: get-var('spacing-05');
-  margin-block-end: get-var('spacing-03');
-}
-
-/* Spacing before the table */
-.#{c.$prefix}-table__title + .#{c.$prefix}-table-overflow,
-.#{c.$prefix}-table__subtitle + .#{c.$prefix}-table-overflow,
-.#{c.$prefix}-table__actions + .#{c.$prefix}-table-overflow {
-  margin-block-start: get-var('spacing-03');
-}
-
-.#{c.$prefix}-table-overflow {
-  grid-area: table;
-}
-
-/* Table -------------------------------------------------------------------- */
-.#{c.$prefix}-table {
+@layer components {
   /* Default table styles */
-  --table-border-radius: #{convert.to-rem(4px)};
-  --table-cell-x-padding: var(--cell-padding-inline, #{get-var('spacing-04')});
-  --table-cell-y-padding: var(--cell-padding-block, #{get-var('spacing-03')});
-  --table-cell-padding: var(--table-cell-y-padding) var(--table-cell-x-padding);
-  --table-font-size: 0.75rem;
-  display: grid;
-  width: 100%;
-  border-spacing: 0;
-  border-collapse: separate;
-  grid-area: table;
-  grid-template-columns: var(--grid-template-columns);
-  @include type.type-style('body-01');
-  /* Density modes: condensed, normal, spacious */
-  &--condensed {
-    --cell-padding-block: #{get-var('spacing-03')};
-    --cell-padding-inline: #{get-var('spacing-04')};
+  .#{c.$prefix}-table-container {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+      'title actions'
+      'subtitle subtitle'
+      'filter filter'
+      'table table'
+      'footer footer';
+    column-gap: get-var('spacing-03');
   }
-  &--normal {
-    --cell-padding-block: #{get-var('spacing-04')};
-    --cell-padding-inline: #{get-var('spacing-05')};
+
+  .#{c.$prefix}-table__title {
+    @include type.type-style('heading-03');
+    margin: 0;
+    color: get-var('text-primary');
+    grid-area: title;
+    align-self: center;
   }
-  &--spacious {
-    --cell-padding-block: #{get-var('spacing-05')};
-    --cell-padding-inline: #{get-var('spacing-06')};
+
+  .#{c.$prefix}-table__subtitle {
+    margin: 0;
+    @include type.type-style('body-01');
+    color: get-var('text-secondary');
+    grid-area: subtitle;
   }
-}
 
-.#{c.$prefix}-table__header,
-.#{c.$prefix}-table__cell {
-  display: flex;
-  padding: var(--table-cell-padding);
-  text-align: start;
-  align-items: center;
-}
+  .#{c.$prefix}-table__actions {
+    display: flex;
+    column-gap: get-var('spacing-03');
+    align-items: center;
+    grid-area: actions;
+    justify-self: end;
+  }
 
-.#{c.$prefix}-table__header:where([data-cell-align='end']),
-.#{c.$prefix}-table__cell:where([data-cell-align='end']) {
-  display: flex;
-  text-align: end;
-  justify-content: flex-end;
-}
+  .#{c.$prefix}-table__divider {
+    width: 100%;
+    height: 1px;
+    background-color: get-var('border-subtle');
+    grid-area: divider;
+    margin-block-start: get-var('spacing-05');
+    margin-block-end: get-var('spacing-03');
+  }
 
-.#{c.$prefix}-table__header[data-cell-align='end'] .#{c.$prefix}-table__sort-btn {
-  display: flex;
-  flex-direction: row-reverse;
-}
+  /* Spacing before the table */
+  .#{c.$prefix}-table__title + .#{c.$prefix}-table-overflow,
+  .#{c.$prefix}-table__subtitle + .#{c.$prefix}-table-overflow,
+  .#{c.$prefix}-table__actions + .#{c.$prefix}-table-overflow {
+    margin-block-start: get-var('spacing-03');
+  }
 
-/* Border radius */
-.#{c.$prefix}-table__head .#{c.$prefix}-table__row:first-of-type .#{c.$prefix}-table__header:first-child {
-  border-top-left-radius: var(--table-border-radius);
-}
+  .#{c.$prefix}-table-overflow {
+    grid-area: table;
+  }
 
-.#{c.$prefix}-table__head .#{c.$prefix}-table__row:first-of-type .#{c.$prefix}-table__header:last-child {
-  border-top-right-radius: var(--table-border-radius);
-}
+  /* Table -------------------------------------------------------------------- */
+  .#{c.$prefix}-table {
+    /* Default table styles */
+    --table-border-radius: #{convert.to-rem(4px)};
+    --table-cell-x-padding: var(--cell-padding-inline, #{get-var('spacing-04')});
+    --table-cell-y-padding: var(--cell-padding-block, #{get-var('spacing-03')});
+    --table-cell-padding: var(--table-cell-y-padding) var(--table-cell-x-padding);
+    --table-font-size: 0.75rem;
+    display: grid;
+    width: 100%;
+    border-spacing: 0;
+    border-collapse: separate;
+    grid-area: table;
+    grid-template-columns: var(--grid-template-columns);
+    @include type.type-style('body-01');
+    /* Density modes: condensed, normal, spacious */
+    &--condensed {
+      --cell-padding-block: #{get-var('spacing-03')};
+      --cell-padding-inline: #{get-var('spacing-04')};
+    }
+    &--normal {
+      --cell-padding-block: #{get-var('spacing-04')};
+      --cell-padding-inline: #{get-var('spacing-05')};
+    }
+    &--spacious {
+      --cell-padding-block: #{get-var('spacing-05')};
+      --cell-padding-inline: #{get-var('spacing-06')};
+    }
+  }
 
-.#{c.$prefix}-table-overflow:last-child
-  .#{c.$prefix}-table
-  .#{c.$prefix}-table__body
-  .#{c.$prefix}-table__row:last-of-type
-  .#{c.$prefix}-table__cell:first-child {
-  border-bottom-left-radius: var(--table-border-radius);
-}
+  .#{c.$prefix}-table__header,
+  .#{c.$prefix}-table__cell {
+    display: flex;
+    padding: var(--table-cell-padding);
+    text-align: start;
+    align-items: center;
+  }
 
-.#{c.$prefix}-table-overflow:last-child
-  .#{c.$prefix}-table
-  .#{c.$prefix}-table__body
-  .#{c.$prefix}-table__row:last-of-type
-  .#{c.$prefix}-table__cell:last-child {
-  border-bottom-right-radius: var(--table-border-radius);
-}
+  .#{c.$prefix}-table__header:where([data-cell-align='end']),
+  .#{c.$prefix}-table__cell:where([data-cell-align='end']) {
+    display: flex;
+    text-align: end;
+    justify-content: flex-end;
+  }
 
-/**
+  .#{c.$prefix}-table__header[data-cell-align='end'] .#{c.$prefix}-table__sort-btn {
+    display: flex;
+    flex-direction: row-reverse;
+  }
+
+  /* Border radius */
+  .#{c.$prefix}-table__head .#{c.$prefix}-table__row:first-of-type .#{c.$prefix}-table__header:first-child {
+    border-top-left-radius: var(--table-border-radius);
+  }
+
+  .#{c.$prefix}-table__head .#{c.$prefix}-table__row:first-of-type .#{c.$prefix}-table__header:last-child {
+    border-top-right-radius: var(--table-border-radius);
+  }
+
+  .#{c.$prefix}-table-overflow:last-child
+    .#{c.$prefix}-table
+    .#{c.$prefix}-table__body
+    .#{c.$prefix}-table__row:last-of-type
+    .#{c.$prefix}-table__cell:first-child {
+    border-bottom-left-radius: var(--table-border-radius);
+  }
+
+  .#{c.$prefix}-table-overflow:last-child
+    .#{c.$prefix}-table
+    .#{c.$prefix}-table__body
+    .#{c.$prefix}-table__row:last-of-type
+    .#{c.$prefix}-table__cell:last-child {
+    border-bottom-right-radius: var(--table-border-radius);
+  }
+
+  /**
 * Offset padding to make sure type aligns regardless of cell padding
 * selection
 */
-.#{c.$prefix}-table__row > *:first-child:not(.#{c.$prefix}-table__cell-skeleton),
-.#{c.$prefix}-table__row > *:first-child .#{c.$prefix}-table__cell-skeleton-item {
-  padding-inline-start: get-var('spacing-05');
-}
-
-.#{c.$prefix}-table__row > *:last-child:not(.#{c.$prefix}-table__cell-skeleton),
-.#{c.$prefix}-table__row > *:last-child .#{c.$prefix}-table__cell-skeleton-item {
-  padding-inline-end: get-var('spacing-05');
-}
-
-/* Table header */
-.#{c.$prefix}-table__header {
-  color: get-var('text-primary');
-  background-color: get-var('layer-accent');
-  font-weight: ff.font-weight('semibold');
-}
-
-.#{c.$prefix}-table__header:where([aria-sort='descending']),
-.#{c.$prefix}-table__header:where([aria-sort='ascending']) {
-  color: get-var('text-primary');
-  background-color: get-var('layer-selected-hover');
-}
-
-.#{c.$prefix}-table__header:hover:has(.#{c.$prefix}-table__sort-btn),
-.#{c.$prefix}-table__header:hover:has(.#{c.$prefix}-table__sort-btn) {
-  background-color: get-var('layer-selected-hover');
-}
-
-/* Table body */
-.#{c.$prefix}-table__body {
-}
-
-/* Table cell */
-.#{c.$prefix}-table__cell {
-  background-color: get-var('layer');
-}
-
-.#{c.$prefix}-table .#{c.$prefix}-table__body .#{c.$prefix}-table__row:not(:last-of-type) .#{c.$prefix}-table__cell {
-  border-bottom: 1px solid get-var('border-subtle');
-}
-
-/* Control visibility of sort icons */
-.#{c.$prefix}-table__sort-icon {
-  width: convert.to-rem(20px);
-  height: convert.to-rem(20px);
-  visibility: hidden;
-}
-
-/* The ASC icon is visible if the header is sortable and is hovered or focused */
-.#{c.$prefix}-table__header:hover .#{c.$prefix}-table__sort-icon--ascending,
-.#{c.$prefix}-table__header .#{c.$prefix}-table__sort-btn:focus .#{c.$prefix}-table__sort-icon--ascending {
-  visibility: visible;
-}
-
-/* Each sort icon is visible if the TableHeader is currently in the corresponding sort state */
-.#{c.$prefix}-table__header[aria-sort='ascending'] .#{c.$prefix}-table__sort-icon--ascending,
-.#{c.$prefix}-table__header[aria-sort='descending'] .#{c.$prefix}-table__sort-icon--descending {
-  visibility: visible;
-}
-
-.#{c.$prefix}-table__cell:where([scope='row']) {
-  display: flex;
-  font-weight: ff.font-weight('semibold');
-  color: get-var('text-primary');
-  align-items: center;
-}
-
-.#{c.$prefix}-table__sort-btn {
-  --btn-height: auto;
-  --btn-width: auto;
-  padding: 0;
-  border: 0 none;
-  column-gap: 0.5rem;
-  inline-size: 100%;
-  block-size: 100%;
-  justify-content: flex-start;
-  font-weight: inherit;
-  color: inherit;
-  background: transparent;
-
-  &:hover,
-  &:focus,
-  &:active {
-    background: transparent;
+  .#{c.$prefix}-table__row > *:first-child:not(.#{c.$prefix}-table__cell-skeleton),
+  .#{c.$prefix}-table__row > *:first-child .#{c.$prefix}-table__cell-skeleton-item {
+    padding-inline-start: get-var('spacing-05');
   }
-}
 
-/* Grid layout */
-.#{c.$prefix}-table__head,
-.#{c.$prefix}-table__body,
-.#{c.$prefix}-table__row {
-  display: contents;
-}
+  .#{c.$prefix}-table__row > *:last-child:not(.#{c.$prefix}-table__cell-skeleton),
+  .#{c.$prefix}-table__row > *:last-child .#{c.$prefix}-table__cell-skeleton-item {
+    padding-inline-end: get-var('spacing-05');
+  }
 
-@supports (grid-template-columns: subgrid) {
+  /* Table header */
+  .#{c.$prefix}-table__header {
+    color: get-var('text-primary');
+    background-color: get-var('layer-accent');
+    font-weight: ff.font-weight('semibold');
+  }
+
+  .#{c.$prefix}-table__header:where([aria-sort='descending']),
+  .#{c.$prefix}-table__header:where([aria-sort='ascending']) {
+    color: get-var('text-primary');
+    background-color: get-var('layer-selected-hover');
+  }
+
+  .#{c.$prefix}-table__header:hover:has(.#{c.$prefix}-table__sort-btn),
+  .#{c.$prefix}-table__header:hover:has(.#{c.$prefix}-table__sort-btn) {
+    background-color: get-var('layer-selected-hover');
+  }
+
+  /* Table body */
+  .#{c.$prefix}-table__body {
+  }
+
+  /* Table cell */
+  .#{c.$prefix}-table__cell {
+    background-color: get-var('layer');
+  }
+
+  .#{c.$prefix}-table .#{c.$prefix}-table__body .#{c.$prefix}-table__row:not(:last-of-type) .#{c.$prefix}-table__cell {
+    border-bottom: 1px solid get-var('border-subtle');
+  }
+
+  /* Control visibility of sort icons */
+  .#{c.$prefix}-table__sort-icon {
+    width: convert.to-rem(20px);
+    height: convert.to-rem(20px);
+    visibility: hidden;
+  }
+
+  /* The ASC icon is visible if the header is sortable and is hovered or focused */
+  .#{c.$prefix}-table__header:hover .#{c.$prefix}-table__sort-icon--ascending,
+  .#{c.$prefix}-table__header .#{c.$prefix}-table__sort-btn:focus .#{c.$prefix}-table__sort-icon--ascending {
+    visibility: visible;
+  }
+
+  /* Each sort icon is visible if the TableHeader is currently in the corresponding sort state */
+  .#{c.$prefix}-table__header[aria-sort='ascending'] .#{c.$prefix}-table__sort-icon--ascending,
+  .#{c.$prefix}-table__header[aria-sort='descending'] .#{c.$prefix}-table__sort-icon--descending {
+    visibility: visible;
+  }
+
+  .#{c.$prefix}-table__cell:where([scope='row']) {
+    display: flex;
+    font-weight: ff.font-weight('semibold');
+    color: get-var('text-primary');
+    align-items: center;
+  }
+
+  .#{c.$prefix}-table__sort-btn {
+    --btn-height: auto;
+    --btn-width: auto;
+    padding: 0;
+    border: 0 none;
+    column-gap: 0.5rem;
+    inline-size: 100%;
+    block-size: 100%;
+    justify-content: flex-start;
+    font-weight: inherit;
+    color: inherit;
+    background: transparent;
+
+    &:hover,
+    &:focus,
+    &:active {
+      background: transparent;
+    }
+  }
+
+  /* Grid layout */
   .#{c.$prefix}-table__head,
   .#{c.$prefix}-table__body,
   .#{c.$prefix}-table__row {
-    display: grid;
-    grid-template-columns: subgrid;
-    grid-column: -1 /1;
+    display: contents;
+  }
+
+  @supports (grid-template-columns: subgrid) {
+    .#{c.$prefix}-table__head,
+    .#{c.$prefix}-table__body,
+    .#{c.$prefix}-table__row {
+      display: grid;
+      grid-template-columns: subgrid;
+      grid-column: -1 /1;
+    }
   }
 }

--- a/packages/styles/scss/components/tag.scss
+++ b/packages/styles/scss/components/tag.scss
@@ -1,69 +1,70 @@
 @use '../config.scss' as c;
 
-// TODO: Finish tag component
+@layer components {
+  // TODO: Finish tag component
+  .#{c.$prefix}-tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.5rem;
+    font-size: var(--font-size-small, 0.875rem);
+    border-radius: 4px;
+    font-weight: var(--font-weight-medium, 500);
+    white-space: nowrap;
+    user-select: none;
+    cursor: default;
+    background-color: red;
+  }
 
-.#{c.$prefix}-tag {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.25rem 0.5rem;
-  font-size: var(--font-size-small, 0.875rem);
-  border-radius: 4px;
-  font-weight: var(--font-weight-medium, 500);
-  white-space: nowrap;
-  user-select: none;
-  cursor: default;
-  background-color: red;
+  /* Sizes */
+  .#{c.$prefix}-tag--small {
+    font-size: var(--font-size-xsmall, 0.75rem);
+    block-size: 1.75rem;
+    padding: 0 0.5rem;
+    border-radius: 4px;
+  }
+
+  .#{c.$prefix}-tag--large {
+    font-size: var(--font-size-medium, 1rem);
+    block-size: 2.5rem;
+    padding: 0 1.25rem;
+    border-radius: 6px;
+  }
+
+  /* Variants */
+
+  /* Types */
+  // .#{c.$prefix}-tag--primary {
+  //   background-color: var(--#{c.$prefix}-tag-primary-bg);
+  //   color: var(--#{c.$prefix}-tag-primary-text);
+  // }
+
+  // .#{c.$prefix}-tag--secondary {
+  //   background-color: var(--#{c.$prefix}-tag-secondary-bg);
+  //   color: var(--#{c.$prefix}-tag-secondary-text);
+  // }
+
+  // .#{c.$prefix}-tag--success {
+  //   background-color: var(--#{c.$prefix}-tag-success-bg);
+  //   color: var(--#{c.$prefix}-tag-success-text);
+  // }
+
+  // .#{c.$prefix}-tag--warning {
+  //   background-color: var(--#{c.$prefix}-tag-warning-bg);
+  //   color: var(--#{c.$prefix}-tag-warning-text);
+  // }
+
+  // .#{c.$prefix}-tag--error {
+  //   background-color: var(--#{c.$prefix}-tag-error-bg);
+  //   color: var(--#{c.$prefix}-tag-error-text);
+  // }
+
+  /* Clickable Tags */
+  // .#{c.$prefix}-tag--clickable {
+  //   cursor: pointer;
+  //   transition: background-color 0.2s ease-in-out;
+  // }
+
+  // .#{c.$prefix}-tag--clickable:hover {
+  //   background-color: var(--#{c.$prefix}-tag-hover);
+  // }
 }
-
-/* Sizes */
-.#{c.$prefix}-tag--small {
-  font-size: var(--font-size-xsmall, 0.75rem);
-  block-size: 1.75rem;
-  padding: 0 0.5rem;
-  border-radius: 4px;
-}
-
-.#{c.$prefix}-tag--large {
-  font-size: var(--font-size-medium, 1rem);
-  block-size: 2.5rem;
-  padding: 0 1.25rem;
-  border-radius: 6px;
-}
-
-/* Variants */
-
-/* Types */
-// .#{c.$prefix}-tag--primary {
-//   background-color: var(--#{c.$prefix}-tag-primary-bg);
-//   color: var(--#{c.$prefix}-tag-primary-text);
-// }
-
-// .#{c.$prefix}-tag--secondary {
-//   background-color: var(--#{c.$prefix}-tag-secondary-bg);
-//   color: var(--#{c.$prefix}-tag-secondary-text);
-// }
-
-// .#{c.$prefix}-tag--success {
-//   background-color: var(--#{c.$prefix}-tag-success-bg);
-//   color: var(--#{c.$prefix}-tag-success-text);
-// }
-
-// .#{c.$prefix}-tag--warning {
-//   background-color: var(--#{c.$prefix}-tag-warning-bg);
-//   color: var(--#{c.$prefix}-tag-warning-text);
-// }
-
-// .#{c.$prefix}-tag--error {
-//   background-color: var(--#{c.$prefix}-tag-error-bg);
-//   color: var(--#{c.$prefix}-tag-error-text);
-// }
-
-/* Clickable Tags */
-// .#{c.$prefix}-tag--clickable {
-//   cursor: pointer;
-//   transition: background-color 0.2s ease-in-out;
-// }
-
-// .#{c.$prefix}-tag--clickable:hover {
-//   background-color: var(--#{c.$prefix}-tag-hover);
-// }

--- a/packages/styles/scss/components/tile.scss
+++ b/packages/styles/scss/components/tile.scss
@@ -2,14 +2,16 @@
 @use '../type/styles.scss' as types;
 @use '../utilities/custom-properties.scss' as cv;
 
-.#{$prefix}-tile {
-  @include types.type-style('body-01');
-  position: relative;
-  display: block;
-  min-block-size: 4rem;
-  min-inline-size: 8rem;
-  outline: 2px solid rgba(0, 0, 0, 0);
-  outline-offset: -2px;
-  background-color: cv.get-var('layer');
-  border-radius: 0.25rem;
+@layer components {
+  .#{$prefix}-tile {
+    @include types.type-style('body-01');
+    position: relative;
+    display: block;
+    min-block-size: 4rem;
+    min-inline-size: 8rem;
+    outline: 2px solid rgba(0, 0, 0, 0);
+    outline-offset: -2px;
+    background-color: cv.get-var('layer');
+    border-radius: 0.25rem;
+  }
 }

--- a/packages/styles/scss/components/tooltip.scss
+++ b/packages/styles/scss/components/tooltip.scss
@@ -2,34 +2,37 @@
 @use '../type/styles.scss' as types;
 @use '../utilities/custom-properties.scss' as cv;
 
-.#{$prefix}-tooltip {
-  --r-tooltip-shadow:
-    0 0 1px var(--r-tooltip-shadow-color-default, #05050629), 0 0 2px var(--r-tooltip-shadow-color-default, #05050629),
-    0 2px 8px var(--r-tooltip-shadow-color-default, #05050629);
-  --r-tooltip-shadow-colored:
-    0 0 1px var(--r-tooltip-shadow-color), 0 0 2px var(--r-tooltip-shadow-color),
-    0 2px 8px var(--r-tooltip-shadow-color);
+@layer components {
+  .#{$prefix}-tooltip {
+    --r-tooltip-shadow:
+      0 0 1px var(--r-tooltip-shadow-color-default, #05050629),
+      0 0 2px var(--r-tooltip-shadow-color-default, #05050629),
+      0 2px 8px var(--r-tooltip-shadow-color-default, #05050629);
+    --r-tooltip-shadow-colored:
+      0 0 1px var(--r-tooltip-shadow-color), 0 0 2px var(--r-tooltip-shadow-color),
+      0 2px 8px var(--r-tooltip-shadow-color);
 
-  &__inner {
-    background: cv.get-var('background-inverse');
-    color: cv.get-var('text-inverse');
-    max-inline-size: 18rem;
-    box-shadow: var(--r-ring-offset-shadow, 0 0 #0000), var(--r-ring-shadow, 0 0 #0000), var(--r-tooltip-shadow);
-    border-radius: 0.25rem;
-    text-align: center;
-    @include types.type-style('body-01');
-    padding: 0.5rem 1rem;
+    &__inner {
+      background: cv.get-var('background-inverse');
+      color: cv.get-var('text-inverse');
+      max-inline-size: 18rem;
+      box-shadow: var(--r-ring-offset-shadow, 0 0 #0000), var(--r-ring-shadow, 0 0 #0000), var(--r-tooltip-shadow);
+      border-radius: 0.25rem;
+      text-align: center;
+      @include types.type-style('body-01');
+      padding: 0.5rem 1rem;
+    }
+
+    &__inner > *:first-child {
+      display: block;
+    }
+
+    &__arrow {
+      fill: cv.get-var('background-inverse');
+    }
   }
 
-  &__inner > *:first-child {
-    display: block;
+  [data-radix-popper-content-wrapper] {
+    z-index: 99999 !important;
   }
-
-  &__arrow {
-    fill: cv.get-var('background-inverse');
-  }
-}
-
-[data-radix-popper-content-wrapper] {
-  z-index: 99999 !important;
 }

--- a/packages/styles/scss/css-variables/variables.scss
+++ b/packages/styles/scss/css-variables/variables.scss
@@ -17,199 +17,202 @@
 /// The core tokens are global colors that are used across components.
 /// Naming is heavily based on the Carbon Design System.
 /// For reference see https://carbondesignsystem.com/elements/color/tokens/
-:root {
-  @include cv.declaration('color-white', get-color('white', '100', 'rgb'));
 
-  /// Backgrounds
-  @include light-dark('background', cv.get-var('color-white'), rgb-color('neutral', '950'));
-  @include light-dark('background-hover', rgb-color('neutral', '100'), rgb-color('neutral', '900'));
-  @include light-dark('background-active', rgb-color('neutral', '200'), rgb-color('neutral', '800'));
-  @include light-dark('background-selected', rgb-color('neutral', '300'), rgb-color('neutral', '700'));
-  @include light-dark('background-selected-hover', rgb-color('neutral', '400'), rgb-color('neutral', '600'));
-  @include light-dark('background-inverse', rgb-color('neutral', '950'), rgb-color('neutral', '50'));
-  @include light-dark('background-inverse-hover', rgb-color('neutral', '500'), rgb-color('neutral', '100'));
+@layer theme {
+  :root {
+    @include cv.declaration('color-white', get-color('white', '100', 'rgb'));
 
-  /// Layer
-  @include light-dark('layer-01', rgb-color('neutral', '100'), rgb-color('neutral', '900'));
-  @include light-dark('layer-02', cv.get-var('color-white'), rgb-color('neutral', '800'));
-  @include light-dark('layer-03', rgb-color('neutral', '200'), rgb-color('neutral', '700'));
-  @include light-dark('layer-hover-01', rgb-color('neutral', '200'), rgb-color('neutral', '800'));
-  @include light-dark('layer-hover-02', rgb-color('neutral', '200'), rgb-color('neutral', '700'));
-  @include light-dark('layer-hover-03', rgb-color('neutral', '300'), rgb-color('neutral', '600'));
-  @include light-dark('layer-active-01', rgb-color('neutral', '300'), rgb-color('neutral', '700'));
-  @include light-dark('layer-active-02', rgb-color('neutral', '300'), rgb-color('neutral', '600'));
-  @include light-dark('layer-active-03', rgb-color('neutral', '400'), rgb-color('neutral', '500'));
-  @include light-dark('layer-selected-01', rgb-color('neutral', '200'), rgb-color('neutral', '800'));
-  @include light-dark('layer-selected-02', rgb-color('neutral', '200'), rgb-color('neutral', '700'));
-  @include light-dark('layer-selected-03', rgb-color('neutral', '300'), rgb-color('neutral', '600'));
-  @include light-dark('layer-selected-hover-01', rgb-color('neutral', '300'), rgb-color('neutral', '700'));
-  @include light-dark('layer-selected-hover-02', rgb-color('neutral', '300'), rgb-color('neutral', '600'));
-  @include light-dark('layer-selected-hover-03', rgb-color('neutral', '400'), rgb-color('neutral', '500'));
+    /// Backgrounds
+    @include light-dark('background', cv.get-var('color-white'), rgb-color('neutral', '950'));
+    @include light-dark('background-hover', rgb-color('neutral', '100'), rgb-color('neutral', '900'));
+    @include light-dark('background-active', rgb-color('neutral', '200'), rgb-color('neutral', '800'));
+    @include light-dark('background-selected', rgb-color('neutral', '300'), rgb-color('neutral', '700'));
+    @include light-dark('background-selected-hover', rgb-color('neutral', '400'), rgb-color('neutral', '600'));
+    @include light-dark('background-inverse', rgb-color('neutral', '950'), rgb-color('neutral', '50'));
+    @include light-dark('background-inverse-hover', rgb-color('neutral', '500'), rgb-color('neutral', '100'));
 
-  /// Layer Accent - Tertiary background paired with $layer-X
-  @include light-dark('layer-accent-01', rgb-color('neutral', '200'), rgb-color('neutral', '800'));
-  @include light-dark('layer-accent-02', rgb-color('neutral', '200'), rgb-color('neutral', '700'));
-  @include light-dark('layer-accent-03', rgb-color('neutral', '300'), rgb-color('neutral', '600'));
-  @include light-dark('layer-accent-hover-01', rgb-color('neutral', '300'), rgb-color('neutral', '700'));
-  @include light-dark('layer-accent-hover-02', rgb-color('neutral', '300'), rgb-color('neutral', '600'));
-  @include light-dark('layer-accent-hover-03', rgb-color('neutral', '400'), rgb-color('neutral', '500'));
-  @include light-dark('layer-accent-active-01', rgb-color('neutral', '400'), rgb-color('neutral', '700'));
-  @include light-dark('layer-accent-active-02', rgb-color('neutral', '400'), rgb-color('neutral', '500'));
-  @include light-dark('layer-accent-active-03', rgb-color('neutral', '500'), rgb-color('neutral', '800'));
+    /// Layer
+    @include light-dark('layer-01', rgb-color('neutral', '100'), rgb-color('neutral', '900'));
+    @include light-dark('layer-02', cv.get-var('color-white'), rgb-color('neutral', '800'));
+    @include light-dark('layer-03', rgb-color('neutral', '200'), rgb-color('neutral', '700'));
+    @include light-dark('layer-hover-01', rgb-color('neutral', '200'), rgb-color('neutral', '800'));
+    @include light-dark('layer-hover-02', rgb-color('neutral', '200'), rgb-color('neutral', '700'));
+    @include light-dark('layer-hover-03', rgb-color('neutral', '300'), rgb-color('neutral', '600'));
+    @include light-dark('layer-active-01', rgb-color('neutral', '300'), rgb-color('neutral', '700'));
+    @include light-dark('layer-active-02', rgb-color('neutral', '300'), rgb-color('neutral', '600'));
+    @include light-dark('layer-active-03', rgb-color('neutral', '400'), rgb-color('neutral', '500'));
+    @include light-dark('layer-selected-01', rgb-color('neutral', '200'), rgb-color('neutral', '800'));
+    @include light-dark('layer-selected-02', rgb-color('neutral', '200'), rgb-color('neutral', '700'));
+    @include light-dark('layer-selected-03', rgb-color('neutral', '300'), rgb-color('neutral', '600'));
+    @include light-dark('layer-selected-hover-01', rgb-color('neutral', '300'), rgb-color('neutral', '700'));
+    @include light-dark('layer-selected-hover-02', rgb-color('neutral', '300'), rgb-color('neutral', '600'));
+    @include light-dark('layer-selected-hover-03', rgb-color('neutral', '400'), rgb-color('neutral', '500'));
 
-  /// Borders
-  @include light-dark('border-interactive', rgb-color('teal', '600'), rgb-color('teal', '700'));
-  /// 00 - Paired with $background
-  @include light-dark('border-subtle-00', rgb-color('neutral', '200'), rgb-color('neutral', '800'));
-  /// 01 - Paired with $layer-01
-  @include light-dark('border-subtle-01', rgb-color('neutral', '300'), rgb-color('neutral', '700'));
-  /// 02 - Paired with $layer-02
-  @include light-dark('border-subtle-02', rgb-color('neutral', '200'), rgb-color('neutral', '800'));
-  /// 03 - Paired with $layer-03
-  @include light-dark('border-subtle-03', rgb-color('neutral', '300'), rgb-color('neutral', '700'));
+    /// Layer Accent - Tertiary background paired with $layer-X
+    @include light-dark('layer-accent-01', rgb-color('neutral', '200'), rgb-color('neutral', '800'));
+    @include light-dark('layer-accent-02', rgb-color('neutral', '200'), rgb-color('neutral', '700'));
+    @include light-dark('layer-accent-03', rgb-color('neutral', '300'), rgb-color('neutral', '600'));
+    @include light-dark('layer-accent-hover-01', rgb-color('neutral', '300'), rgb-color('neutral', '700'));
+    @include light-dark('layer-accent-hover-02', rgb-color('neutral', '300'), rgb-color('neutral', '600'));
+    @include light-dark('layer-accent-hover-03', rgb-color('neutral', '400'), rgb-color('neutral', '500'));
+    @include light-dark('layer-accent-active-01', rgb-color('neutral', '400'), rgb-color('neutral', '700'));
+    @include light-dark('layer-accent-active-02', rgb-color('neutral', '400'), rgb-color('neutral', '500'));
+    @include light-dark('layer-accent-active-03', rgb-color('neutral', '500'), rgb-color('neutral', '800'));
 
-  /// Text
-  @include light-dark('text-primary', rgb-color('neutral', '950'), rgb-color('neutral', '100'));
-  @include light-dark('text-secondary', rgb-color('neutral', '700'), rgb-color('neutral', '300'));
-  @include light-dark('text-placeholder', rgb-color('neutral', '400'), rgb-color('neutral', '600'));
-  @include light-dark('text-on-color', cv.get-var('color-white'), rgb-color('neutral', '100'));
-  @include light-dark('text-inverse', rgb-color('neutral', '100'), rgb-color('neutral', '950'));
+    /// Borders
+    @include light-dark('border-interactive', rgb-color('teal', '600'), rgb-color('teal', '700'));
+    /// 00 - Paired with $background
+    @include light-dark('border-subtle-00', rgb-color('neutral', '200'), rgb-color('neutral', '800'));
+    /// 01 - Paired with $layer-01
+    @include light-dark('border-subtle-01', rgb-color('neutral', '300'), rgb-color('neutral', '700'));
+    /// 02 - Paired with $layer-02
+    @include light-dark('border-subtle-02', rgb-color('neutral', '200'), rgb-color('neutral', '800'));
+    /// 03 - Paired with $layer-03
+    @include light-dark('border-subtle-03', rgb-color('neutral', '300'), rgb-color('neutral', '700'));
 
-  /// Button
-  @include light-dark('button-primary', rgb-color('teal', '600'), rgb-color('teal', '800'));
-  @include light-dark('button-primary-border', rgb-color('teal', '600'), rgb-color('teal', '700'));
-  @include light-dark('button-primary-hover', rgb-color('teal', '700'), rgb-color('teal', '700'));
-  @include light-dark('button-primary-border-hover', rgb-color('teal', '700'), rgb-color('teal', '600'));
-  @include light-dark('button-primary-active', rgb-color('teal', '800'), rgb-color('teal', '600'));
-  @include light-dark('button-primary-border-active', rgb-color('teal', '800'), rgb-color('teal', '500'));
-  @include light-dark('button-secondary', rgb-color('neutral', '800'), rgb-color('neutral', '800'));
-  @include light-dark('button-secondary-border', rgb-color('neutral', '800'), rgb-color('neutral', '700'));
-  @include light-dark('button-tertiary', cv.get-var('color-white'), rgb-color('neutral', '800'));
-  @include light-dark('button-tertiary-border', rgb-color('teal', '600'), rgb-color('neutral', '900'));
-  @include light-dark('button-danger', rgb-color('red', '600'), rgb-color('red', '800'));
-  @include light-dark('button-danger-border', rgb-color('red', '600'), rgb-color('red', '900'));
+    /// Text
+    @include light-dark('text-primary', rgb-color('neutral', '950'), rgb-color('neutral', '100'));
+    @include light-dark('text-secondary', rgb-color('neutral', '700'), rgb-color('neutral', '300'));
+    @include light-dark('text-placeholder', rgb-color('neutral', '400'), rgb-color('neutral', '600'));
+    @include light-dark('text-on-color', cv.get-var('color-white'), rgb-color('neutral', '100'));
+    @include light-dark('text-inverse', rgb-color('neutral', '100'), rgb-color('neutral', '950'));
 
-  /// Icons
-  @include light-dark('icon-primary', rgb-color('neutral', '950'), rgb-color('neutral', '100'));
-  @include light-dark('icon-secondary', rgb-color('neutral', '700'), rgb-color('neutral', '300'));
+    /// Button
+    @include light-dark('button-primary', rgb-color('teal', '600'), rgb-color('teal', '800'));
+    @include light-dark('button-primary-border', rgb-color('teal', '600'), rgb-color('teal', '700'));
+    @include light-dark('button-primary-hover', rgb-color('teal', '700'), rgb-color('teal', '700'));
+    @include light-dark('button-primary-border-hover', rgb-color('teal', '700'), rgb-color('teal', '600'));
+    @include light-dark('button-primary-active', rgb-color('teal', '800'), rgb-color('teal', '600'));
+    @include light-dark('button-primary-border-active', rgb-color('teal', '800'), rgb-color('teal', '500'));
+    @include light-dark('button-secondary', rgb-color('neutral', '800'), rgb-color('neutral', '800'));
+    @include light-dark('button-secondary-border', rgb-color('neutral', '800'), rgb-color('neutral', '700'));
+    @include light-dark('button-tertiary', cv.get-var('color-white'), rgb-color('neutral', '800'));
+    @include light-dark('button-tertiary-border', rgb-color('teal', '600'), rgb-color('neutral', '900'));
+    @include light-dark('button-danger', rgb-color('red', '600'), rgb-color('red', '800'));
+    @include light-dark('button-danger-border', rgb-color('red', '600'), rgb-color('red', '900'));
 
-  /// Links
-  @include light-dark('link-primary', rgb-color('teal', '500'), rgb-color('teal', '400'));
-  @include light-dark('link-primary-hover', rgb-color('teal', '600'), rgb-color('teal', '300'));
+    /// Icons
+    @include light-dark('icon-primary', rgb-color('neutral', '950'), rgb-color('neutral', '100'));
+    @include light-dark('icon-secondary', rgb-color('neutral', '700'), rgb-color('neutral', '300'));
 
-  /// Metrics
-  @include light-dark('metrics-blue', rgb-color('blue', '400'), rgb-color('blue', '500'));
-  @include light-dark('metrics-red', rgb-color('red', '400'), rgb-color('red', '500'));
-  @include light-dark('metrics-amber', rgb-color('amber', '400'), rgb-color('amber', '500'));
-  @include light-dark('metrics-orange', rgb-color('orange', '400'), rgb-color('orange', '500'));
-  @include light-dark('metrics-yellow', rgb-color('yellow', '400'), rgb-color('yellow', '500'));
-  @include light-dark('metrics-lime', rgb-color('lime', '400'), rgb-color('lime', '500'));
-  @include light-dark('metrics-green', rgb-color('green', '400'), rgb-color('green', '500'));
-  @include light-dark('metrics-emerald', rgb-color('emerald', '400'), rgb-color('emerald', '500'));
+    /// Links
+    @include light-dark('link-primary', rgb-color('teal', '500'), rgb-color('teal', '400'));
+    @include light-dark('link-primary-hover', rgb-color('teal', '600'), rgb-color('teal', '300'));
 
-  /// Status
-  @include light-dark('support-error', rgb-color('red', '500'), rgb-color('red', '400'));
-  @include light-dark('support-success', rgb-color('green', '500'), rgb-color('green', '400'));
-  @include light-dark('support-warning', rgb-color('yellow', '500'), rgb-color('yellow', '400'));
-  @include light-dark('support-info', rgb-color('blue', '500'), rgb-color('blue', '400'));
-  @include light-dark('support-caution-minor', rgb-color('yellow', '500'), rgb-color('yellow', '400'));
-  @include light-dark('support-caution-major', rgb-color('orange', '500'), rgb-color('orange', '400'));
-  @include light-dark('support-caution-undefined', rgb-color('purple', '500'), rgb-color('purple', '400'));
+    /// Metrics
+    @include light-dark('metrics-blue', rgb-color('blue', '400'), rgb-color('blue', '500'));
+    @include light-dark('metrics-red', rgb-color('red', '400'), rgb-color('red', '500'));
+    @include light-dark('metrics-amber', rgb-color('amber', '400'), rgb-color('amber', '500'));
+    @include light-dark('metrics-orange', rgb-color('orange', '400'), rgb-color('orange', '500'));
+    @include light-dark('metrics-yellow', rgb-color('yellow', '400'), rgb-color('yellow', '500'));
+    @include light-dark('metrics-lime', rgb-color('lime', '400'), rgb-color('lime', '500'));
+    @include light-dark('metrics-green', rgb-color('green', '400'), rgb-color('green', '500'));
+    @include light-dark('metrics-emerald', rgb-color('emerald', '400'), rgb-color('emerald', '500'));
 
-  // Spacing
-  @include spacing.emit-spacing-custom-properties();
-}
+    /// Status
+    @include light-dark('support-error', rgb-color('red', '500'), rgb-color('red', '400'));
+    @include light-dark('support-success', rgb-color('green', '500'), rgb-color('green', '400'));
+    @include light-dark('support-warning', rgb-color('yellow', '500'), rgb-color('yellow', '400'));
+    @include light-dark('support-info', rgb-color('blue', '500'), rgb-color('blue', '400'));
+    @include light-dark('support-caution-minor', rgb-color('yellow', '500'), rgb-color('yellow', '400'));
+    @include light-dark('support-caution-major', rgb-color('orange', '500'), rgb-color('orange', '400'));
+    @include light-dark('support-caution-undefined', rgb-color('purple', '500'), rgb-color('purple', '400'));
 
-@supports (color: oklch(0% 0 0)) {
-  @media (color-gamut: p3) {
-    :root {
-      @include cv.declaration('color-white', get-color('white', '100', 'p3'));
-      /// Backgrounds
-      @include light-dark('background', cv.get-var('color-white'), p3-color('neutral', '950'));
-      @include light-dark('background-hover', p3-color('neutral', '100'), p3-color('neutral', '900'));
-      @include light-dark('background-active', p3-color('neutral', '200'), p3-color('neutral', '800'));
-      @include light-dark('background-selected', p3-color('neutral', '300'), p3-color('neutral', '700'));
-      @include light-dark('background-selected-hover', p3-color('neutral', '400'), p3-color('neutral', '600'));
-      @include light-dark('background-inverse', p3-color('neutral', '950'), p3-color('neutral', '50'));
-      @include light-dark('background-inverse-hover', p3-color('neutral', '500'), p3-color('neutral', '100'));
+    // Spacing
+    @include spacing.emit-spacing-custom-properties();
+  }
 
-      /// Layer
-      @include light-dark('layer-01', p3-color('neutral', '100'), p3-color('neutral', '900'));
-      @include light-dark('layer-02', cv.get-var('color-white'), p3-color('neutral', '800'));
-      @include light-dark('layer-03', p3-color('neutral', '200'), p3-color('neutral', '700'));
-      @include light-dark('layer-hover-01', p3-color('neutral', '200'), p3-color('neutral', '800'));
-      @include light-dark('layer-hover-02', p3-color('neutral', '200'), p3-color('neutral', '700'));
-      @include light-dark('layer-hover-03', p3-color('neutral', '300'), p3-color('neutral', '600'));
-      @include light-dark('layer-active-01', p3-color('neutral', '300'), p3-color('neutral', '700'));
-      @include light-dark('layer-active-02', p3-color('neutral', '300'), p3-color('neutral', '600'));
-      @include light-dark('layer-active-03', p3-color('neutral', '400'), p3-color('neutral', '500'));
-      @include light-dark('layer-selected-01', p3-color('neutral', '200'), p3-color('neutral', '800'));
-      @include light-dark('layer-selected-02', p3-color('neutral', '200'), p3-color('neutral', '700'));
-      @include light-dark('layer-selected-03', p3-color('neutral', '300'), p3-color('neutral', '600'));
-      @include light-dark('layer-selected-hover-01', p3-color('neutral', '300'), p3-color('neutral', '700'));
-      @include light-dark('layer-selected-hover-02', p3-color('neutral', '300'), p3-color('neutral', '600'));
-      @include light-dark('layer-selected-hover-03', p3-color('neutral', '400'), p3-color('neutral', '500'));
+  @supports (color: oklch(0% 0 0)) {
+    @media (color-gamut: p3) {
+      :root {
+        @include cv.declaration('color-white', get-color('white', '100', 'p3'));
+        /// Backgrounds
+        @include light-dark('background', cv.get-var('color-white'), p3-color('neutral', '950'));
+        @include light-dark('background-hover', p3-color('neutral', '100'), p3-color('neutral', '900'));
+        @include light-dark('background-active', p3-color('neutral', '200'), p3-color('neutral', '800'));
+        @include light-dark('background-selected', p3-color('neutral', '300'), p3-color('neutral', '700'));
+        @include light-dark('background-selected-hover', p3-color('neutral', '400'), p3-color('neutral', '600'));
+        @include light-dark('background-inverse', p3-color('neutral', '950'), p3-color('neutral', '50'));
+        @include light-dark('background-inverse-hover', p3-color('neutral', '500'), p3-color('neutral', '100'));
 
-      /// Layer Accent - Tertiary background paired with $layer-X
-      @include light-dark('layer-accent-01', p3-color('neutral', '200'), p3-color('neutral', '800'));
-      @include light-dark('layer-accent-02', p3-color('neutral', '200'), p3-color('neutral', '700'));
-      @include light-dark('layer-accent-03', p3-color('neutral', '300'), p3-color('neutral', '600'));
-      @include light-dark('layer-accent-hover-01', p3-color('neutral', '300'), p3-color('neutral', '700'));
-      @include light-dark('layer-accent-hover-02', p3-color('neutral', '300'), p3-color('neutral', '600'));
-      @include light-dark('layer-accent-hover-03', p3-color('neutral', '400'), p3-color('neutral', '500'));
-      @include light-dark('layer-accent-active-01', p3-color('neutral', '400'), p3-color('neutral', '700'));
-      @include light-dark('layer-accent-active-02', p3-color('neutral', '400'), p3-color('neutral', '500'));
-      @include light-dark('layer-accent-active-03', p3-color('neutral', '500'), p3-color('neutral', '800'));
+        /// Layer
+        @include light-dark('layer-01', p3-color('neutral', '100'), p3-color('neutral', '900'));
+        @include light-dark('layer-02', cv.get-var('color-white'), p3-color('neutral', '800'));
+        @include light-dark('layer-03', p3-color('neutral', '200'), p3-color('neutral', '700'));
+        @include light-dark('layer-hover-01', p3-color('neutral', '200'), p3-color('neutral', '800'));
+        @include light-dark('layer-hover-02', p3-color('neutral', '200'), p3-color('neutral', '700'));
+        @include light-dark('layer-hover-03', p3-color('neutral', '300'), p3-color('neutral', '600'));
+        @include light-dark('layer-active-01', p3-color('neutral', '300'), p3-color('neutral', '700'));
+        @include light-dark('layer-active-02', p3-color('neutral', '300'), p3-color('neutral', '600'));
+        @include light-dark('layer-active-03', p3-color('neutral', '400'), p3-color('neutral', '500'));
+        @include light-dark('layer-selected-01', p3-color('neutral', '200'), p3-color('neutral', '800'));
+        @include light-dark('layer-selected-02', p3-color('neutral', '200'), p3-color('neutral', '700'));
+        @include light-dark('layer-selected-03', p3-color('neutral', '300'), p3-color('neutral', '600'));
+        @include light-dark('layer-selected-hover-01', p3-color('neutral', '300'), p3-color('neutral', '700'));
+        @include light-dark('layer-selected-hover-02', p3-color('neutral', '300'), p3-color('neutral', '600'));
+        @include light-dark('layer-selected-hover-03', p3-color('neutral', '400'), p3-color('neutral', '500'));
 
-      /// Borders
-      /// 00 - Paired with $background
-      @include light-dark('border-subtle-00', p3-color('neutral', '200'), p3-color('neutral', '800'));
-      /// 01 - Paired with $layer-01
-      @include light-dark('border-subtle-01', p3-color('neutral', '300'), p3-color('neutral', '700'));
-      /// 02 - Paired with $layer-02
-      @include light-dark('border-subtle-02', p3-color('neutral', '200'), p3-color('neutral', '800'));
-      /// 03 - Paired with $layer-03
-      @include light-dark('border-subtle-03', p3-color('neutral', '300'), p3-color('neutral', '700'));
+        /// Layer Accent - Tertiary background paired with $layer-X
+        @include light-dark('layer-accent-01', p3-color('neutral', '200'), p3-color('neutral', '800'));
+        @include light-dark('layer-accent-02', p3-color('neutral', '200'), p3-color('neutral', '700'));
+        @include light-dark('layer-accent-03', p3-color('neutral', '300'), p3-color('neutral', '600'));
+        @include light-dark('layer-accent-hover-01', p3-color('neutral', '300'), p3-color('neutral', '700'));
+        @include light-dark('layer-accent-hover-02', p3-color('neutral', '300'), p3-color('neutral', '600'));
+        @include light-dark('layer-accent-hover-03', p3-color('neutral', '400'), p3-color('neutral', '500'));
+        @include light-dark('layer-accent-active-01', p3-color('neutral', '400'), p3-color('neutral', '700'));
+        @include light-dark('layer-accent-active-02', p3-color('neutral', '400'), p3-color('neutral', '500'));
+        @include light-dark('layer-accent-active-03', p3-color('neutral', '500'), p3-color('neutral', '800'));
 
-      /// Text
-      @include light-dark('text-primary', p3-color('neutral', '950'), p3-color('neutral', '100'));
-      @include light-dark('text-secondary', p3-color('neutral', '700'), p3-color('neutral', '300'));
-      @include light-dark('text-placeholder', p3-color('neutral', '400'), p3-color('neutral', '600'));
-      @include light-dark('text-on-color', p3-color('teal', '950'), p3-color('teal', '200'));
-      @include light-dark('text-inverse', p3-color('neutral', '100'), p3-color('neutral', '950'));
+        /// Borders
+        /// 00 - Paired with $background
+        @include light-dark('border-subtle-00', p3-color('neutral', '200'), p3-color('neutral', '800'));
+        /// 01 - Paired with $layer-01
+        @include light-dark('border-subtle-01', p3-color('neutral', '300'), p3-color('neutral', '700'));
+        /// 02 - Paired with $layer-02
+        @include light-dark('border-subtle-02', p3-color('neutral', '200'), p3-color('neutral', '800'));
+        /// 03 - Paired with $layer-03
+        @include light-dark('border-subtle-03', p3-color('neutral', '300'), p3-color('neutral', '700'));
 
-      /// Button
-      @include light-dark('button-primary', p3-color('teal', '500'), p3-color('teal', '800'));
-      @include light-dark('button-primary-border', p3-color('teal', '600'), p3-color('teal', '700'));
-      @include light-dark('button-secondary', p3-color('neutral', '300'), p3-color('neutral', '800'));
-      @include light-dark('button-secondary-border', p3-color('neutral', '400'), p3-color('neutral', '900'));
+        /// Text
+        @include light-dark('text-primary', p3-color('neutral', '950'), p3-color('neutral', '100'));
+        @include light-dark('text-secondary', p3-color('neutral', '700'), p3-color('neutral', '300'));
+        @include light-dark('text-placeholder', p3-color('neutral', '400'), p3-color('neutral', '600'));
+        @include light-dark('text-on-color', p3-color('teal', '950'), p3-color('teal', '200'));
+        @include light-dark('text-inverse', p3-color('neutral', '100'), p3-color('neutral', '950'));
 
-      /// Icons
-      @include light-dark('icon-primary', p3-color('neutral', '950'), p3-color('neutral', '100'));
-      @include light-dark('icon-secondary', p3-color('neutral', '700'), p3-color('neutral', '300'));
+        /// Button
+        @include light-dark('button-primary', p3-color('teal', '500'), p3-color('teal', '800'));
+        @include light-dark('button-primary-border', p3-color('teal', '600'), p3-color('teal', '700'));
+        @include light-dark('button-secondary', p3-color('neutral', '300'), p3-color('neutral', '800'));
+        @include light-dark('button-secondary-border', p3-color('neutral', '400'), p3-color('neutral', '900'));
 
-      /// Links
-      @include light-dark('link-primary', p3-color('teal', '500'), p3-color('teal', '400'));
-      @include light-dark('link-primary-hover', p3-color('teal', '600'), p3-color('teal', '300'));
+        /// Icons
+        @include light-dark('icon-primary', p3-color('neutral', '950'), p3-color('neutral', '100'));
+        @include light-dark('icon-secondary', p3-color('neutral', '700'), p3-color('neutral', '300'));
 
-      /// Metrics
-      @include light-dark('metrics-blue', p3-color('blue', '400'), p3-color('blue', '500'));
-      @include light-dark('metrics-red', p3-color('red', '400'), p3-color('red', '500'));
-      @include light-dark('metrics-amber', p3-color('amber', '400'), p3-color('amber', '500'));
-      @include light-dark('metrics-orange', p3-color('orange', '400'), p3-color('orange', '500'));
-      @include light-dark('metrics-yellow', p3-color('yellow', '400'), p3-color('yellow', '500'));
-      @include light-dark('metrics-lime', p3-color('lime', '400'), p3-color('lime', '500'));
-      @include light-dark('metrics-green', p3-color('green', '400'), p3-color('green', '500'));
-      @include light-dark('metrics-emerald', p3-color('emerald', '400'), p3-color('emerald', '500'));
+        /// Links
+        @include light-dark('link-primary', p3-color('teal', '500'), p3-color('teal', '400'));
+        @include light-dark('link-primary-hover', p3-color('teal', '600'), p3-color('teal', '300'));
 
-      /// Status
-      @include light-dark('support-error', p3-color('red', '500'), p3-color('red', '400'));
-      @include light-dark('support-success', p3-color('green', '500'), p3-color('green', '400'));
-      @include light-dark('support-warning', p3-color('yellow', '500'), p3-color('yellow', '400'));
-      @include light-dark('support-info', p3-color('blue', '500'), p3-color('blue', '400'));
-      @include light-dark('support-caution-minor', p3-color('yellow', '500'), p3-color('yellow', '400'));
-      @include light-dark('support-caution-major', p3-color('orange', '500'), p3-color('orange', '400'));
-      @include light-dark('support-caution-undefined', p3-color('purple', '500'), p3-color('purple', '400'));
+        /// Metrics
+        @include light-dark('metrics-blue', p3-color('blue', '400'), p3-color('blue', '500'));
+        @include light-dark('metrics-red', p3-color('red', '400'), p3-color('red', '500'));
+        @include light-dark('metrics-amber', p3-color('amber', '400'), p3-color('amber', '500'));
+        @include light-dark('metrics-orange', p3-color('orange', '400'), p3-color('orange', '500'));
+        @include light-dark('metrics-yellow', p3-color('yellow', '400'), p3-color('yellow', '500'));
+        @include light-dark('metrics-lime', p3-color('lime', '400'), p3-color('lime', '500'));
+        @include light-dark('metrics-green', p3-color('green', '400'), p3-color('green', '500'));
+        @include light-dark('metrics-emerald', p3-color('emerald', '400'), p3-color('emerald', '500'));
+
+        /// Status
+        @include light-dark('support-error', p3-color('red', '500'), p3-color('red', '400'));
+        @include light-dark('support-success', p3-color('green', '500'), p3-color('green', '400'));
+        @include light-dark('support-warning', p3-color('yellow', '500'), p3-color('yellow', '400'));
+        @include light-dark('support-info', p3-color('blue', '500'), p3-color('blue', '400'));
+        @include light-dark('support-caution-minor', p3-color('yellow', '500'), p3-color('yellow', '400'));
+        @include light-dark('support-caution-major', p3-color('orange', '500'), p3-color('orange', '400'));
+        @include light-dark('support-caution-undefined', p3-color('purple', '500'), p3-color('purple', '400'));
+      }
     }
   }
 }

--- a/packages/styles/scss/layer.scss
+++ b/packages/styles/scss/layer.scss
@@ -53,5 +53,7 @@
 }
 
 @if $css--layer-tokens == true {
-  @include emit-layer-custom-properties;
+  @layer base {
+    @include emit-layer-custom-properties;
+  }
 }

--- a/packages/styles/scss/reset.scss
+++ b/packages/styles/scss/reset.scss
@@ -93,5 +93,7 @@
 }
 
 @if config.$css--reset == true {
-  @include emit-reset-style;
+  @layer base {
+    @include emit-reset-style;
+  }
 }


### PR DESCRIPTION
This PR introduces [cascading layers](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer) to the styles package. It declares the same layers that tailwind uses in order to make the two libraries compatible. 

These layers are defined in the following order (same as tailwind)
1. theme
2. base
3. components
4. utilities

Before this change there was an issue where a utility class from tailwind could not override the styling from a component styling from the styles package.

With these change all components should be wrapped in the component layer, e.g. 
```.scss
@layer components {
  .#{$prefix}-some-component { ... }
}
```

After this change any tailwind utility class can override the styling of a component.