### PR TITLE
feat(web): add environment tag to display environments with consistency

### DIFF
--- a/apps/web/app/clusters/[id]/metadata-card.tsx
+++ b/apps/web/app/clusters/[id]/metadata-card.tsx
@@ -1,7 +1,7 @@
 'use client'
 import type { Cluster } from '@ror/js-api-client'
 import clsxm from '@/utils/clsxm'
-import { Tile, CodeSnippet, Layer, DefinitionDescription, DefinitionList, DefinitionTerm, Tag } from '@ror/react'
+import { Tile, CodeSnippet, Layer, DefinitionDescription, DefinitionList, DefinitionTerm } from '@ror/react'
 import { format } from 'date-fns'
 import { nb } from 'date-fns/locale/nb'
 import { EnvironmentTag } from '@/components/common/environment-tag'

--- a/apps/web/app/clusters/[id]/metadata-card.tsx
+++ b/apps/web/app/clusters/[id]/metadata-card.tsx
@@ -4,6 +4,7 @@ import clsxm from '@/utils/clsxm'
 import { Tile, CodeSnippet, Layer, DefinitionDescription, DefinitionList, DefinitionTerm, Tag } from '@ror/react'
 import { format } from 'date-fns'
 import { nb } from 'date-fns/locale/nb'
+import { EnvironmentTag } from '@/components/common/environment-tag'
 
 interface ClusterMetadataCardProps {
   cluster: Cluster
@@ -80,9 +81,9 @@ export function ClusterMetadataCard({ cluster, className }: ClusterMetadataCardP
           <div className='flex flex-col gap-1'>
             <DefinitionTerm>Environment</DefinitionTerm>
             <DefinitionDescription>
-              <Tag size='sm' variant='readonly'>
+              <EnvironmentTag environment={cluster.environment} size='sm' variant='readonly'>
                 {cluster.environment}
-              </Tag>
+              </EnvironmentTag>
             </DefinitionDescription>
           </div>
           <div className='flex flex-col gap-1'>

--- a/apps/web/components/common/environment-tag.tsx
+++ b/apps/web/components/common/environment-tag.tsx
@@ -1,0 +1,25 @@
+import { Tag, TagColor, TagProps } from '@ror/react'
+
+type Environment = 'development' | 'dev' | 'test' | 'staging' | 'production' | 'prod' | 'qa'
+
+const mapEnvironmentToColor: Record<Environment | string, TagColor> = {
+  dev: 'blue',
+  development: 'blue',
+  staging: 'purple',
+  test: 'green',
+  production: 'red',
+  prod: 'red',
+  qa: 'yellow',
+}
+
+interface EnvironmentTagProps extends Omit<TagProps, 'color'> {
+  environment: Environment | string
+}
+
+/**
+ * Display environment as a tag using consistent color for the different environments
+ */
+export function EnvironmentTag({ environment }: EnvironmentTagProps) {
+  const color = mapEnvironmentToColor[environment] ?? 'gray'
+  return <Tag color={color}>{environment}</Tag>
+}

--- a/packages/react/src/main.tsx
+++ b/packages/react/src/main.tsx
@@ -33,3 +33,4 @@ export {
 export { Tile } from './components/tile.tsx'
 export { Tooltip, TooltipProvider } from './components/tooltip.tsx'
 export { Tag } from './components/tag.tsx'
+export type { TagProps, TagColor, TagVariant } from './components/tag.tsx'


### PR DESCRIPTION
This pull request adds an environment tag to the web application to display environments with consistency. Meaning the `dev`, `prod`, `test` e.t.c is always displayed with the same color.