### PR TITLE
feat(web): add access group component

### DIFF
--- a/apps/web/src/app/(protected)/clusters/[id]/access-group-card.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/access-group-card.tsx
@@ -1,0 +1,30 @@
+import clsxm from '@/utils/clsxm'
+import { Cluster } from '@ror/js-api-client'
+import { Stack } from '@ror/react'
+import { Layer } from '@ror/react/components/layer'
+import { Tile } from '@ror/react/components/tile'
+interface ClusterAccessGroupCardProps {
+  cluster: Cluster
+  className?: string
+}
+
+export function ClusterAccessGroupCard({ cluster, className }: ClusterAccessGroupCardProps) {
+
+  const classes = clsxm('p-5', className)
+  console.log("cluster", cluster)
+
+  return (
+    <Tile className={classes}>
+      <h3 className='heading-01 pb-3 mb-5 border-b border-b-(--r-border-subtle)'>Access Groups</h3>
+      <Layer level={1}>
+        <Stack gap={5} className='max-w-full'>
+            <ul className='list-disc list-inside '>
+                {cluster.acl.accessGroups.map((group) => (
+                    <li key={group} className='mb-3 last:mb-0' >{group}</li>
+                ))}
+            </ul>
+        </Stack>
+      </Layer>
+    </Tile>
+  )
+}

--- a/apps/web/src/app/(protected)/clusters/[id]/page.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/page.tsx
@@ -5,6 +5,7 @@ import { ClusterMetadataCard } from './metadata-card'
 import { ClusterToolsCard } from './tools-card'
 import { ClusterVersionsCard } from './versions-card'
 import { ClusterMetrics } from './cluster-metrics'
+import { ClusterAccessGroupCard } from './access-group-card'
 
 interface ClusterPageProps {
   params: Promise<{
@@ -29,6 +30,7 @@ export default async function ClusterPage({ params }: ClusterPageProps) {
       <ClusterMetadataCard cluster={cluster} className='col-span-12 @5xl:col-span-6' />
       <ClusterVersionsCard cluster={cluster} className='col-span-12 @2xl:col-span-6 @5xl:col-span-3' />
       <ClusterToolsCard cluster={cluster} user={session.user} className='col-span-12 @2xl:col-span-6 @5xl:col-span-3' />
+      <ClusterAccessGroupCard  cluster={cluster} className='col-span-12 @2xl:col-span-6 @5xl:col-span-3' />
     </div>
   )
 }

--- a/packages/js-api-client/lib/resources/clusters/clusters.model.ts
+++ b/packages/js-api-client/lib/resources/clusters/clusters.model.ts
@@ -75,6 +75,10 @@ export const TopologyModel = z.object({
   }),
 })
 
+export const AclModel = z.object({
+  accessGroups: z.array(z.string()),
+})
+
 export const Cluster = z
   .object({
     clusterId: z.string(),
@@ -103,18 +107,27 @@ export const Cluster = z
     topology: TopologyModel,
     versions: VersionsModel,
     workspace: WorkspaceModel,
-    ingresses: z.union([
-      z.array(
-        z.object({
-          ingressrules: z.array(
-            z.object({
-              hostname: z.string().optional(),
-            }).optional()
-          ).optional(),
-        }).optional()
-      ), 
-      z.null()
-    ]).optional(),
+    ingresses: z
+      .union([
+        z.array(
+          z
+            .object({
+              ingressrules: z
+                .array(
+                  z
+                    .object({
+                      hostname: z.string().optional(),
+                    })
+                    .optional()
+                )
+                .optional(),
+            })
+            .optional()
+        ),
+        z.null(),
+      ])
+      .optional(),
+    acl: AclModel,
   })
   .passthrough()
 


### PR DESCRIPTION
This PR adds a card to display access groups on the cluster page. In doing so, acl is added to the api client. The component is displayed in the picture.

![image](https://github.com/user-attachments/assets/71248c14-7ad9-4069-8be5-883d3ed9f045)
