### PR TITLE
feat(vite): disable emptyOutDir

### DIFF
--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -76,6 +76,6 @@ export default defineConfig({
         preserveDirectives(),
       ],
     },
-    emptyOutDir: true,
+    emptyOutDir: false,
   },
 })


### PR DESCRIPTION
By disabling the `emptyOutDir` option, Vite will not clear the output directory before each build, which can reduce the amount of work the development server needs to do on each file change, potentially leading to better performance.