### PR TITLE
feature/node-pools

### DIFF
--- a/apps/web/__mocks__/data/clusters.ts
+++ b/apps/web/__mocks__/data/clusters.ts
@@ -1,7 +1,7 @@
 import { Health } from '@ror/js-api-client'
 import { sub } from 'date-fns'
 
-export default [
+const clusters = [
   {
     id: '6523967984fddd1597f6166f',
     identifier: 'aaa-001-dev-kgfh',
@@ -529,3 +529,5 @@ export default [
     },
   },
 ]
+
+export default clusters

--- a/apps/web/__mocks__/data/nodes.ts
+++ b/apps/web/__mocks__/data/nodes.ts
@@ -1,0 +1,7 @@
+// import { Health } from '@ror/js-api-client'
+// import { sub } from 'date-fns'
+import { Nodes } from '@ror/js-api-client'
+
+const nodes: Nodes = []
+
+export default nodes

--- a/apps/web/__mocks__/data/nodes.ts
+++ b/apps/web/__mocks__/data/nodes.ts
@@ -1,7 +1,186 @@
 // import { Health } from '@ror/js-api-client'
 // import { sub } from 'date-fns'
-import { Nodes } from '@ror/js-api-client'
+import { NodeResponse } from '@ror/js-api-client'
 
-const nodes: Nodes = []
+const nodes: NodeResponse = {
+  resources: [
+    {
+      kind: 'Node',
+      apiVersion: 'v1',
+      metadata: {
+        name: 't-aaa-001-control-plane-6ffkc',
+        uid: '3f346038-0136-4f0d-9aa6-3c277c37a14e',
+        resourceVersion: '493788292',
+        creationTimestamp: '2025-01-31T15:00:54Z',
+        labels: {},
+        annotations: {},
+        managedFields: [],
+      },
+      rormeta: {
+        version: 'v2',
+        hash: '5884478303314410569',
+        ownerref: { scope: 'cluster', subject: 'aaa-001-dev' },
+        action: 'Update',
+      },
+      node: {
+        spec: {},
+        status: {
+          addresses: null,
+          capacity: {
+            cpu: '',
+            ephemeralStorage: '',
+            memory: '',
+            pods: '',
+          },
+          conditions: null,
+          nodeInfo: {
+            architecture: 'amd64',
+            bootID: '',
+            containerRuntimeVersion: '',
+            kernelVersion: '',
+            kubeProxyVersion: '',
+            kubeletVersion: '',
+            machineID: '',
+            operatingSystem: '',
+            osImage: 'VMware Photon OS/Linux',
+            systemUUID: '',
+          },
+        },
+      },
+    },
+    {
+      kind: 'Node',
+      apiVersion: 'v1',
+      metadata: {
+        name: 't-aaa-001-workers-f4jpw-f4hxf-h5g2n',
+        uid: '9408a85e-901c-48ec-bd4b-4de4a44c82be',
+        resourceVersion: '493788565',
+        creationTimestamp: '2025-01-31T15:14:58Z',
+        labels: {},
+        annotations: {},
+        managedFields: [],
+      },
+      rormeta: {
+        version: 'v2',
+        hash: '2592243034891482106',
+        ownerref: { scope: 'cluster', subject: 'aaa-001-dev' },
+        action: 'Update',
+      },
+      node: {
+        spec: {},
+        status: {
+          addresses: null,
+          capacity: {
+            cpu: '',
+            ephemeralStorage: '',
+            memory: '',
+            pods: '',
+          },
+          conditions: null,
+          nodeInfo: {
+            architecture: 'amd64',
+            bootID: '',
+            containerRuntimeVersion: '',
+            kernelVersion: '',
+            kubeProxyVersion: '',
+            kubeletVersion: '',
+            machineID: '',
+            operatingSystem: '',
+            osImage: 'VMware Photon OS/Linux',
+            systemUUID: '',
+          },
+        },
+      },
+    },
+    {
+      kind: 'Node',
+      apiVersion: 'v1',
+      metadata: {
+        name: 't-aaa-001-workers-f4jpw-f4hxf-lmcrl',
+        uid: '4a4ceb1e-0131-47a5-b566-4ed2d5f2f07f',
+        resourceVersion: '493782257',
+        creationTimestamp: '2025-01-31T15:10:22Z',
+        labels: {},
+        annotations: {},
+        managedFields: [],
+      },
+      rormeta: {
+        version: 'v2',
+        hash: '2412552037763072509',
+        ownerref: { scope: 'cluster', subject: 'aaa-001-dev' },
+        action: 'Update',
+      },
+      node: {
+        spec: {},
+        status: {
+          addresses: null,
+          capacity: {
+            cpu: '',
+            ephemeralStorage: '',
+            memory: '',
+            pods: '',
+          },
+          conditions: null,
+          nodeInfo: {
+            architecture: 'amd64',
+            bootID: '',
+            containerRuntimeVersion: '',
+            kernelVersion: '',
+            kubeProxyVersion: '',
+            kubeletVersion: '',
+            machineID: '',
+            operatingSystem: '',
+            osImage: 'VMware Photon OS/Linux',
+            systemUUID: '',
+          },
+        },
+      },
+    },
+    {
+      kind: 'Node',
+      apiVersion: 'v1',
+      metadata: {
+        name: 't-aaa-001-workers-f4jpw-f4hxf-w2mhs',
+        uid: '3d70c520-1a20-4d38-b1dc-1200381ee7bf',
+        resourceVersion: '493788829',
+        creationTimestamp: '2025-01-31T15:06:54Z',
+        labels: {},
+        annotations: {},
+        managedFields: [],
+      },
+      rormeta: {
+        version: 'v2',
+        hash: '4944169613020978094',
+        ownerref: { scope: 'cluster', subject: 'aaa-001-dev' },
+        action: 'Update',
+      },
+      node: {
+        spec: {},
+        status: {
+          addresses: null,
+          capacity: {
+            cpu: '',
+            ephemeralStorage: '',
+            memory: '',
+            pods: '',
+          },
+          conditions: null,
+          nodeInfo: {
+            architecture: 'amd64',
+            bootID: '',
+            containerRuntimeVersion: '',
+            kernelVersion: '',
+            kubeProxyVersion: '',
+            kubeletVersion: '',
+            machineID: '',
+            operatingSystem: '',
+            osImage: 'VMware Photon OS/Linux',
+            systemUUID: '',
+          },
+        },
+      },
+    },
+  ],
+}
 
 export default nodes

--- a/apps/web/__mocks__/handlers.ts
+++ b/apps/web/__mocks__/handlers.ts
@@ -1,3 +1,4 @@
 import { clustersHandlers } from './handlers/clusters'
+import { nodesHandlers } from './handlers/nodes'
 
-export const handlers = [...clustersHandlers]
+export const handlers = [...clustersHandlers, ...nodesHandlers]

--- a/apps/web/__mocks__/handlers/nodes.ts
+++ b/apps/web/__mocks__/handlers/nodes.ts
@@ -6,4 +6,10 @@ export const nodesHandlers = [
   http.get(getRorAPIPath('/v2/resources'), () => {
     return HttpResponse.json(nodes)
   }),
+  http.get(
+    'http://localhost:10000/v2/resources%3Fkind=Node&apiversion=general.ror.internal%2Fv1alpha1&ownerScope=cluster&ownerSubject=aaa-001-dev-kgfh',
+    () => {
+      return HttpResponse.json(nodes)
+    }
+  ),
 ]

--- a/apps/web/__mocks__/handlers/nodes.ts
+++ b/apps/web/__mocks__/handlers/nodes.ts
@@ -1,0 +1,9 @@
+import { http, HttpResponse } from 'msw'
+import { getRorAPIPath } from '../utils/mock-base-url'
+import nodes from '../data/nodes'
+
+export const nodesHandlers = [
+  http.get(getRorAPIPath('/v2/resources'), () => {
+    return HttpResponse.json(nodes)
+  }),
+]

--- a/apps/web/src/app/(protected)/clusters/[id]/layout.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/layout.tsx
@@ -18,6 +18,7 @@ interface ClusterPageLayoutProps {
 const {
   cluster,
   clusterIngresses,
+  clusterNodePools,
   clusterPolicies,
   clusterVulnerabilities,
   clusterCompliance,
@@ -34,6 +35,10 @@ const createTabNavigationItems = (clusterId: string) => {
     {
       label: clusterIngresses.label,
       href: clusterIngresses.getHref(clusterId),
+    },
+    {
+      label: clusterNodePools.label,
+      href: clusterNodePools.getHref(clusterId),
     },
     {
       label: clusterPolicies.label,

--- a/apps/web/src/app/(protected)/clusters/[id]/node-pools/node-pools-table.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/node-pools/node-pools-table.tsx
@@ -1,0 +1,28 @@
+'use client'
+import { DataTable } from '@/components/ui/data-table'
+import { Node } from '@ror/js-api-client'
+import { ColumnDef, createColumnHelper } from '@tanstack/react-table'
+
+const columnHelper = createColumnHelper<Node>()
+
+const columns = [
+  columnHelper.accessor('metadata.name', {
+    id: 'name',
+    header: 'Name',
+  }),
+  columnHelper.accessor('node.status.nodeInfo.osImage', {
+    header: 'OS Image',
+  }) as ColumnDef<Node>,
+  columnHelper.accessor('node.status.nodeInfo.architecture', {
+    header: 'Architecture',
+  }) as ColumnDef<Node>,
+] satisfies ColumnDef<Node>[]
+
+interface NodePoolsTableProps {
+  nodes: Node[]
+}
+
+export function NodePoolsTable({ nodes }: NodePoolsTableProps) {
+  const totalRows = Array.isArray(nodes) ? nodes.length : 0
+  return <DataTable data={nodes} columns={columns} totalCount={totalRows} />
+}

--- a/apps/web/src/app/(protected)/clusters/[id]/node-pools/node-pools-table.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/node-pools/node-pools-table.tsx
@@ -9,12 +9,15 @@ const columns = [
   columnHelper.accessor('metadata.name', {
     id: 'name',
     header: 'Name',
+    enableSorting: false,
   }),
   columnHelper.accessor('node.status.nodeInfo.osImage', {
     header: 'OS Image',
+    enableSorting: false,
   }) as ColumnDef<Node>,
   columnHelper.accessor('node.status.nodeInfo.architecture', {
     header: 'Architecture',
+    enableSorting: false,
   }) as ColumnDef<Node>,
 ] satisfies ColumnDef<Node>[]
 

--- a/apps/web/src/app/(protected)/clusters/[id]/node-pools/page.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/node-pools/page.tsx
@@ -1,5 +1,6 @@
 import { authGuard } from '@/features/auth/utils/auth-guard'
 import { rorApiClient } from '@/services/ror-api'
+import { NodePoolsTable } from './node-pools-table'
 
 interface NodePoolsPageProps {
   params: Promise<{ id: string }>
@@ -10,13 +11,13 @@ export default async function NodePoolsPage({ params }: NodePoolsPageProps) {
   const session = await authGuard()
   const client = rorApiClient(session.accessToken)
 
-  const nodes = await client.nodes.listByCluster(id)
+  const response = await client.nodes.listByCluster(id)
 
-  console.log(nodes)
+  const nodes = response.resources
 
   return (
     <div>
-      <h1>Node Pools</h1>
+      <NodePoolsTable nodes={nodes} />
     </div>
   )
 }

--- a/apps/web/src/app/(protected)/clusters/[id]/node-pools/page.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/node-pools/page.tsx
@@ -1,11 +1,16 @@
 import { authGuard } from '@/features/auth/utils/auth-guard'
 import { rorApiClient } from '@/services/ror-api'
 
-export default async function NodePoolsPage() {
+interface NodePoolsPageProps {
+  params: Promise<{ id: string }>
+}
+
+export default async function NodePoolsPage({ params }: NodePoolsPageProps) {
+  const { id } = await params
   const session = await authGuard()
   const client = rorApiClient(session.accessToken)
 
-  const nodes = await client.nodes.list()
+  const nodes = await client.nodes.listByCluster(id)
 
   console.log(nodes)
 

--- a/apps/web/src/app/(protected)/clusters/[id]/node-pools/page.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/node-pools/page.tsx
@@ -1,0 +1,17 @@
+import { authGuard } from '@/features/auth/utils/auth-guard'
+import { rorApiClient } from '@/services/ror-api'
+
+export default async function NodePoolsPage() {
+  const session = await authGuard()
+  const client = rorApiClient(session.accessToken)
+
+  const nodes = await client.nodes.list()
+
+  console.log(nodes)
+
+  return (
+    <div>
+      <h1>Node Pools</h1>
+    </div>
+  )
+}

--- a/apps/web/src/components/ui/data-table/data-table.tsx
+++ b/apps/web/src/components/ui/data-table/data-table.tsx
@@ -61,17 +61,17 @@ export interface DataTableProps<TData> extends Omit<TableProps, 'gridTemplateCol
   /**
    * The current state of pagination
    */
-  pagination: DataTablePagination
+  pagination?: DataTablePagination
 
   /**
    * The callback when pagination changes
    */
-  onPaginationChange: (state: DataTablePagination) => void
+  onPaginationChange?: (state: DataTablePagination) => void
 
   /**
    * Provide the number of pages available for pagination
    */
-  pageCount: number
+  pageCount?: number
 
   /**
    * Provide a custom set of different page sizes
@@ -121,14 +121,18 @@ export function DataTable<TData>(props: DataTableProps<TData>) {
      * Trigger callback when pagination changes
      */
     onPaginationChange: (updater) => {
-      const newValue = updater instanceof Function ? updater(props.pagination) : updater
-      onPaginationChange(newValue)
+      if (props.pagination && typeof onPaginationChange === 'function') {
+        const newValue = updater instanceof Function ? updater(props.pagination) : updater
+        onPaginationChange(newValue)
+      }
     },
 
     enableSorting: true,
     onSortingChange: (updater) => {
-      const newState = updater instanceof Function ? updater(props.sorting) : updater
-      onSortingChange(newState)
+      if (props.sorting && typeof onSortingChange === 'function') {
+        const newState = updater instanceof Function ? updater(props.sorting) : updater
+        onSortingChange(newState)
+      }
     },
 
     /**

--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -26,6 +26,10 @@ export const routes = {
       label: 'Ingresses',
       getHref: (id: string) => `/clusters/${id}/ingresses`,
     },
+    clusterNodePools: {
+      label: 'Node pools',
+      getHref: (id: string) => `/clusters/${id}/node-pools`,
+    },
     clusterPolicies: {
       label: 'Policies',
       getHref: (id: string) => `/clusters/${id}/policies`,

--- a/packages/js-api-client/lib/client-factory.ts
+++ b/packages/js-api-client/lib/client-factory.ts
@@ -1,6 +1,7 @@
 import { RorApiError, RorForbiddenError, RorNotFoundError, RorUnauthorizedError } from './error'
 import { createClustersResource } from './resources/clusters/clusters.resource'
 import { createUsersResource } from './resources/users/users.resource'
+import { createNodesResource } from './resources/nodes/nodes.resource'
 import type { ApiClientConfig, RequestConfig, RetryPolicyConfig, Middleware } from './types'
 
 const DEFAULT_MAX_RETRIES = 3
@@ -103,5 +104,6 @@ export function createApiClient(config: ApiClientConfig, middlewares: Middleware
     client: baseClient,
     users: createUsersResource(baseClient),
     clusters: createClustersResource(baseClient),
+    nodes: createNodesResource(baseClient),
   }
 }

--- a/packages/js-api-client/lib/constants.ts
+++ b/packages/js-api-client/lib/constants.ts
@@ -1,4 +1,4 @@
 export const enum ResourceKind {
   KubernetesCluster = 'KubernetesCluster',
-  Nodes = 'Nodes',
+  Node = 'Node',
 }

--- a/packages/js-api-client/lib/constants.ts
+++ b/packages/js-api-client/lib/constants.ts
@@ -1,0 +1,4 @@
+export const enum ResourceKind {
+  KubernetesCluster = 'KubernetesCluster',
+  Nodes = 'Nodes',
+}

--- a/packages/js-api-client/lib/index.ts
+++ b/packages/js-api-client/lib/index.ts
@@ -6,3 +6,4 @@ export type {
   ClusterListItemType as ClusterListItem,
 } from './resources/clusters/clusters.types'
 export { Health } from './resources/generic-models/health'
+export type { Node, Nodes } from './resources/nodes/nodes.types'

--- a/packages/js-api-client/lib/index.ts
+++ b/packages/js-api-client/lib/index.ts
@@ -6,4 +6,4 @@ export type {
   ClusterListItemType as ClusterListItem,
 } from './resources/clusters/clusters.types'
 export { Health } from './resources/generic-models/health'
-export type { Node, Nodes } from './resources/nodes/nodes.types'
+export type { Node, NodeResponse } from './resources/nodes/nodes.types'

--- a/packages/js-api-client/lib/resources/generic-models/resource-response.ts
+++ b/packages/js-api-client/lib/resources/generic-models/resource-response.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod'
+
+const ResourceMetaDataSchema = z.object({})
+
+const RorMetaDataSchema = z.object({})
+
+/**
+ * A resource schema contains information that is always returned by the API.
+ * No matter what type of resource that is returned.
+ *
+ * @remarks
+ * The schema is meant to be extended by other schemas.
+ *
+ */
+export const ResourceSchema = z.object({
+  kind: z.string(),
+  apiVersion: z.string(),
+  metadata: ResourceMetaDataSchema.passthrough(),
+  rormeta: RorMetaDataSchema.passthrough(),
+})
+
+export const createResourceResponseSchema = <T>(schema: z.ZodType<T>) =>
+  z.object({
+    resources: z.array(schema),
+  })

--- a/packages/js-api-client/lib/resources/nodes/nodes.model.ts
+++ b/packages/js-api-client/lib/resources/nodes/nodes.model.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { createResourceResponseSchema, ResourceSchema } from '../generic-models/resource-response'
 
 const NodeSpecTaint = z.object({
   effect: z.string(),
@@ -47,17 +48,19 @@ const NodeStatusNodeInfo = z.object({
 })
 
 const NodeStatusSchema = z.object({
-  addresses: z.array(NodeStatusAddress),
+  addresses: z.array(NodeStatusAddress).nullable(),
   capacity: NodeStatusCapacity,
-  conditions: z.array(NodeStatusCondition),
+  conditions: z.array(NodeStatusCondition).nullable(),
   nodeInfo: NodeStatusNodeInfo,
 })
 
-export const NodeSchema = z.object({
-  // How it should be
-  spec: NodeSpecSchema,
-  // How it is right now
-  status: NodeStatusSchema,
+export const NodeSchema = ResourceSchema.extend({
+  node: z.object({
+    // How it should be
+    spec: NodeSpecSchema,
+    // How it is right now
+    status: NodeStatusSchema,
+  }),
 })
 
-export const NodesSchema = z.array(NodeSchema)
+export const NodeResponseSchema = createResourceResponseSchema(NodeSchema)

--- a/packages/js-api-client/lib/resources/nodes/nodes.model.ts
+++ b/packages/js-api-client/lib/resources/nodes/nodes.model.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod'
+
+const NodeSpecTaint = z.object({
+  effect: z.string(),
+  key: z.string(),
+})
+
+const NodeSpecSchema = z.object({
+  podCIDR: z.string().optional(),
+  podCIDRs: z.array(z.string()).optional(),
+  providerID: z.string().optional(),
+  taints: z.array(NodeSpecTaint).optional(),
+})
+
+const NodeStatusAddress = z.object({
+  address: z.string(),
+  type: z.string(),
+})
+
+const NodeStatusCapacity = z.object({
+  cpu: z.string(),
+  ephemeralStorage: z.string(),
+  memory: z.string(),
+  pods: z.string(),
+})
+
+const NodeStatusCondition = z.object({
+  lastHeartbeatTime: z.string(),
+  lastTransitionTime: z.string(),
+  message: z.string(),
+  reason: z.string(),
+  status: z.string(),
+  type: z.string(),
+})
+
+const NodeStatusNodeInfo = z.object({
+  architecture: z.string(),
+  bootID: z.string(),
+  containerRuntimeVersion: z.string(),
+  kernelVersion: z.string(),
+  kubeProxyVersion: z.string(),
+  kubeletVersion: z.string(),
+  machineID: z.string(),
+  operatingSystem: z.string(),
+  osImage: z.string(),
+  systemUUID: z.string(),
+})
+
+const NodeStatusSchema = z.object({
+  addresses: z.array(NodeStatusAddress),
+  capacity: NodeStatusCapacity,
+  conditions: z.array(NodeStatusCondition),
+  nodeInfo: NodeStatusNodeInfo,
+})
+
+export const NodeSchema = z.object({
+  // How it should be
+  spec: NodeSpecSchema,
+  // How it is right now
+  status: NodeStatusSchema,
+})
+
+export const NodesSchema = z.array(NodeSchema)

--- a/packages/js-api-client/lib/resources/nodes/nodes.resource.ts
+++ b/packages/js-api-client/lib/resources/nodes/nodes.resource.ts
@@ -1,0 +1,32 @@
+import { ResourceKind } from '../../constants'
+import { createResource, type ResourceClient } from '../create-resource'
+import { NodeSchema, NodesSchema } from './nodes.model'
+import type { Node, Nodes } from './nodes.types'
+
+export interface NodeResource {
+  list: () => Promise<Nodes>
+  get: (id: string) => Promise<Node>
+}
+
+export const createNodesResource = (client: ResourceClient): NodeResource => {
+  const resource = createResource(client)
+
+  return {
+    list: async () => {
+      const searchParams = new URLSearchParams()
+      searchParams.set('ownerScope', 'node')
+      searchParams.set('ownerSubject', 'ror scope: node')
+      searchParams.set('apiversion', 'general.ror.internal/v1alpha1')
+      searchParams.set('kind', ResourceKind.Nodes)
+      const url = `/v2/resources?${searchParams.toString()}`
+      const response = await resource.get(url)
+      const validatedData = NodesSchema.parse(response)
+      return validatedData
+    },
+    get: async (id: string) => {
+      const url = `/v2/resources/uuid/${id}`
+      const response = await resource.get(url)
+      return NodeSchema.parse(response)
+    },
+  }
+}

--- a/packages/js-api-client/lib/resources/nodes/nodes.resource.ts
+++ b/packages/js-api-client/lib/resources/nodes/nodes.resource.ts
@@ -1,11 +1,12 @@
 import { ResourceKind } from '../../constants'
 import { createResource, type ResourceClient } from '../create-resource'
-import { NodeSchema, NodesSchema } from './nodes.model'
-import type { Node, Nodes } from './nodes.types'
+import { NodeSchema, NodeResponseSchema } from './nodes.model'
+import type { Node, NodeResponse } from './nodes.types'
 
 export interface NodeResource {
-  list: () => Promise<Nodes>
+  list: () => Promise<NodeResponse>
   get: (id: string) => Promise<Node>
+  listByCluster: (clusterId: string) => Promise<NodeResponse>
 }
 
 export const createNodesResource = (client: ResourceClient): NodeResource => {
@@ -14,19 +15,31 @@ export const createNodesResource = (client: ResourceClient): NodeResource => {
   return {
     list: async () => {
       const searchParams = new URLSearchParams()
-      searchParams.set('ownerScope', 'node')
+      searchParams.set('ownerScope', 'Node')
       searchParams.set('ownerSubject', 'ror scope: node')
       searchParams.set('apiversion', 'general.ror.internal/v1alpha1')
-      searchParams.set('kind', ResourceKind.Nodes)
+      searchParams.set('kind', ResourceKind.Node)
       const url = `/v2/resources`
       const response = await resource.get(url)
-      const validatedData = NodesSchema.parse(response)
+      const validatedData = NodeResponseSchema.parse(response)
       return validatedData
     },
     get: async (id: string) => {
       const url = `/v2/resources/uuid/${id}`
       const response = await resource.get(url)
       return NodeSchema.parse(response)
+    },
+    listByCluster: async (clusterId: string) => {
+      const searchParams = new URLSearchParams()
+      searchParams.set('kind', ResourceKind.Node)
+      searchParams.set('apiversion', 'general.ror.internal/v1alpha1')
+      searchParams.set('ownerScope', 'cluster')
+      searchParams.set('ownerSubject', clusterId)
+
+      const url = `/v2/resources?${searchParams.toString()}`
+      const response = await resource.get(url)
+      const validatedData = NodeResponseSchema.parse(response)
+      return validatedData
     },
   }
 }

--- a/packages/js-api-client/lib/resources/nodes/nodes.resource.ts
+++ b/packages/js-api-client/lib/resources/nodes/nodes.resource.ts
@@ -18,7 +18,7 @@ export const createNodesResource = (client: ResourceClient): NodeResource => {
       searchParams.set('ownerSubject', 'ror scope: node')
       searchParams.set('apiversion', 'general.ror.internal/v1alpha1')
       searchParams.set('kind', ResourceKind.Nodes)
-      const url = `/v2/resources?${searchParams.toString()}`
+      const url = `/v2/resources`
       const response = await resource.get(url)
       const validatedData = NodesSchema.parse(response)
       return validatedData

--- a/packages/js-api-client/lib/resources/nodes/nodes.types.ts
+++ b/packages/js-api-client/lib/resources/nodes/nodes.types.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { NodeSchema, NodesSchema } from './nodes.model'
+import { NodeSchema, NodeResponseSchema } from './nodes.model'
 
 export type Node = z.infer<typeof NodeSchema>
-export type Nodes = z.infer<typeof NodesSchema>
+export type NodeResponse = z.infer<typeof NodeResponseSchema>

--- a/packages/js-api-client/lib/resources/nodes/nodes.types.ts
+++ b/packages/js-api-client/lib/resources/nodes/nodes.types.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod'
+import { NodeSchema, NodesSchema } from './nodes.model'
+
+export type Node = z.infer<typeof NodeSchema>
+export type Nodes = z.infer<typeof NodesSchema>


### PR DESCRIPTION
Here is a suggested pull request description based on the provided context:

This pull request adds a new "Node Pools" tab to the Cluster page, allowing users to view the node pools associated with their Kubernetes cluster.

- Added support for fetching nodes for a cluster in `js-api-client`
- Added mocking for fetching nodes for a cluster (based on v2/resources endpoint)
- Added a new `NodePoolsTable` component to display the list of node pools
- Added a new tab to access the node pool information.

### Other changes
- Made the pagination and sorting features of the `DataTable` component optional

Co-authored by: @hanlun0804 and @patrickedqvist 