### PR TITLE
refactor(styles): remove prefix config

### DIFF
--- a/packages/styles/scss/components/breadcrumb.scss
+++ b/packages/styles/scss/components/breadcrumb.scss
@@ -1,9 +1,8 @@
-@use '../config.scss' as c;
 @use '../type/styles.scss' as types;
 @use '../utilities/custom-properties.scss' as cv;
 
 @layer components {
-  .#{c.$prefix}-breadcrumb {
+  .r-breadcrumb {
     box-sizing: border-box;
     padding: 0;
     border: 0;
@@ -15,7 +14,7 @@
     display: inline;
   }
 
-  .#{c.$prefix}-breadcrumb__item {
+  .r-breadcrumb__item {
     position: relative;
     display: flex;
     align-items: center;
@@ -34,7 +33,7 @@
     }
   }
 
-  .#{c.$prefix}-breadcrumb__link {
+  .r-breadcrumb__link {
     padding: 0;
     border: 0;
     margin: 0;
@@ -53,12 +52,12 @@
     }
   }
 
-  .#{c.$prefix}-breadcrumb--no-trailing-slash .#{c.$prefix}-breadcrumb__item:last-child::after {
+  .r-breadcrumb--no-trailing-slash .r-breadcrumb__item:last-child::after {
     content: '';
   }
 
   @media (min-width: 42rem) {
-    .#{c.$prefix}-breadcrumb {
+    .r-breadcrumb {
       display: flex;
       flex-wrap: wrap;
     }

--- a/packages/styles/scss/components/button.scss
+++ b/packages/styles/scss/components/button.scss
@@ -1,9 +1,8 @@
-@use '../config.scss' as c;
 @use '../type/styles.scss' as types;
 @use '../utilities/custom-properties.scss' as cv;
 
 @layer components {
-  .#{c.$prefix}-btn {
+  .r-btn {
     --btn-height: 2rem;
     --btn-x-padding: #{cv.get-var('spacing-05')};
     block-size: var(--btn-height);
@@ -32,23 +31,23 @@
     @include types.type-style('body-01');
   }
 
-  .#{c.$prefix}-btn--sm {
+  .r-btn--sm {
     --btn-height: 1.75rem;
     border-radius: 4px;
   }
 
-  .#{c.$prefix}-btn--md {
+  .r-btn--md {
     --btn-height: 2rem;
     padding: 0 1rem;
     border-radius: 4px;
   }
 
-  .#{c.$prefix}-btn--lg {
+  .r-btn--lg {
     --btn-height: 2.5rem;
     border-radius: 6px;
   }
 
-  .#{c.$prefix}-btn--primary {
+  .r-btn--primary {
     background: cv.get-var('button-primary');
     border-color: cv.get-var('button-primary-border');
     color: cv.get-var('text-on-color');
@@ -64,49 +63,49 @@
     }
   }
 
-  .#{c.$prefix}-btn--secondary {
+  .r-btn--secondary {
     background: cv.get-var('button-secondary');
     border-color: cv.get-var('button-secondary-border');
     color: cv.get-var('text-on-color');
   }
 
-  .#{c.$prefix}-btn--tertiary {
+  .r-btn--tertiary {
     background: cv.get-var('button-tertiary');
     border-color: cv.get-var('button-tertiary-border');
     color: cv.get-var('button-primary');
   }
 
-  .#{c.$prefix}-btn--danger {
+  .r-btn--danger {
     background: cv.get-var('button-danger');
     border-color: cv.get-var('button-danger-border');
     color: cv.get-var('text-on-color');
   }
 
-  .#{c.$prefix}-btn--ghost {
+  .r-btn--ghost {
     border-color: transparent;
     background-color: transparent;
   }
 
-  .#{c.$prefix}-btn--ghost:hover {
+  .r-btn--ghost:hover {
     background: cv.get-var('background-hover');
   }
 
-  .#{c.$prefix}-btn--ghost.#{c.$prefix}-btn--icon-only[disabled] {
+  .r-btn--ghost.r-btn--icon-only[disabled] {
     cursor: not-allowed;
   }
 
-  .#{c.$prefix}-btn--ghost.#{c.$prefix}-btn--icon-only[disabled] svg {
+  .r-btn--ghost.r-btn--icon-only[disabled] svg {
     color: cv.get-var('icon-disabled');
   }
 
-  .#{c.$prefix}-btn--icon-only {
+  .r-btn--icon-only {
     justify-content: center;
     padding: 0;
     inline-size: var(--btn-height);
     block-size: var(--btn-height);
   }
 
-  .#{c.$prefix}-btn--icon-only svg {
+  .r-btn--icon-only svg {
     min-inline-size: 1rem;
     inline-size: 1rem;
     block-size: 1rem;

--- a/packages/styles/scss/components/code-snippet.scss
+++ b/packages/styles/scss/components/code-snippet.scss
@@ -1,9 +1,8 @@
-@use '../config.scss' as *;
 @use '../utilities/custom-properties.scss' as cv;
 @use '../type/styles.scss' as type;
 
 @layer components {
-  .#{$prefix}-code-snippet {
+  .r-code-snippet {
     --code-snippet-multi-max-height: 16rem;
     background-color: cv.get-var('layer');
     color: cv.get-var('text-primary');
@@ -11,28 +10,28 @@
   }
 
   /// Base
-  .#{$prefix}-code-snippet code {
+  .r-code-snippet code {
     @include type.type-style('code-01');
   }
 
-  .#{$prefix}-code-snippet pre {
+  .r-code-snippet pre {
     margin: 0;
   }
 
-  .#{$prefix}-code-snippet__overflow-indicator--right {
+  .r-code-snippet__overflow-indicator--right {
     order: 2;
     background-image: linear-gradient(to right, transparent, cv.get-var('layer'));
     margin-inline-start: -1rem;
   }
 
-  .#{$prefix}-code-snippet__overflow-indicator--left,
-  .#{$prefix}-code-snippet__overflow-indicator--right {
+  .r-code-snippet__overflow-indicator--left,
+  .r-code-snippet__overflow-indicator--right {
     z-index: 1;
     flex: 1 0 auto;
     inline-size: 1rem;
   }
 
-  .#{$prefix}-code-snippet__copy-btn {
+  .r-code-snippet__copy-btn {
     position: absolute;
     inset-block-start: 0;
     inset-inline-end: 0;
@@ -40,7 +39,7 @@
   }
 
   /// Inline
-  .#{$prefix}-code-snippet--inline {
+  .r-code-snippet--inline {
     position: relative;
     display: inline;
     padding: 0;
@@ -49,7 +48,7 @@
     cursor: pointer;
   }
 
-  .#{$prefix}-code-snippet--inline.#{$prefix}-btn {
+  .r-code-snippet--inline.r-btn {
     block-size: 1.25rem;
     inline-size: initial;
     max-inline-size: unset;
@@ -57,12 +56,12 @@
     padding-inline: 0;
   }
 
-  .#{$prefix}-code-snippet--inline code {
+  .r-code-snippet--inline code {
     padding-inline: 0.5rem;
   }
 
   /// Single
-  .#{$prefix}-code-snippet--single {
+  .r-code-snippet--single {
     position: relative;
     inline-size: 100%;
     max-inline-size: 48rem;
@@ -73,7 +72,7 @@
     border-radius: 0.125rem;
   }
 
-  .#{$prefix}-code-snippet--single .#{$prefix}-code-snippet__container {
+  .r-code-snippet--single .r-code-snippet__container {
     position: relative;
     display: flex;
     align-items: center;
@@ -83,32 +82,32 @@
     scrollbar-width: none;
   }
 
-  .#{$prefix}-code-snippet--single .#{$prefix}-code-snippet__overflow-indicator--right {
+  .r-code-snippet--single .r-code-snippet__overflow-indicator--right {
     inset-inline-end: 2.5rem;
   }
 
-  .#{$prefix}-code-snippet--single .#{$prefix}-code-snippet__overflow-indicator--right,
-  .#{$prefix}-code-snippet--single .#{$prefix}-code-snippet__overflow-indicator--left {
+  .r-code-snippet--single .r-code-snippet__overflow-indicator--right,
+  .r-code-snippet--single .r-code-snippet__overflow-indicator--left {
     position: absolute;
     block-size: calc(100% - 0.25rem);
     inline-size: 2rem;
   }
 
-  .#{$prefix}-code-snippet--single pre,
-  .#{$prefix}-code-snippet--inline code {
+  .r-code-snippet--single pre,
+  .r-code-snippet--inline code {
     white-space: pre;
   }
 
-  .#{$prefix}-code-snippet--single pre {
+  .r-code-snippet--single pre {
     padding-inline-end: 0.5rem;
   }
 
   /// Multi
-  .#{$prefix}-code-snippet--multi {
+  .r-code-snippet--multi {
     padding: 1rem;
   }
 
-  .#{$prefix}-code-snippet--multi .#{$prefix}-code-snippet__container {
+  .r-code-snippet--multi .r-code-snippet__container {
     position: relative;
     order: 1;
     overflow: auto;

--- a/packages/styles/scss/components/content-switch.scss
+++ b/packages/styles/scss/components/content-switch.scss
@@ -1,11 +1,10 @@
-@use '../config.scss' as *;
 @use '../utilities/convert.scss';
 @use '../utilities/custom-properties.scss' as cv;
 @use '../layout.scss';
 @use '../type/styles.scss' as type;
 
 @layer components {
-  .#{$prefix}-content-switch {
+  .r-content-switch {
     --content-switch-border-radius: #{convert.to-rem(4px)};
     --content-switch-padding-inline: #{cv.get-var('spacing-05')};
     display: flex;
@@ -13,31 +12,31 @@
     inline-size: 100%;
   }
 
-  .#{$prefix}-content-switch--sm {
+  .r-content-switch--sm {
     block-size: layout.height('sm');
   }
 
-  .#{$prefix}-content-switch--md {
+  .r-content-switch--md {
     block-size: layout.height('md');
   }
 
-  .#{$prefix}-content-switch--lg {
+  .r-content-switch--lg {
     block-size: layout.height('lg');
   }
 
-  .#{$prefix}-content-switch__tab:first-child {
+  .r-content-switch__tab:first-child {
     border-start-start-radius: var(--content-switch-border-radius);
     border-end-start-radius: var(--content-switch-border-radius);
     border-inline-start: convert.to-rem(1px) solid cv.get-var('border-inverse');
   }
 
-  .#{$prefix}-content-switch__tab:last-child {
+  .r-content-switch__tab:last-child {
     border-start-end-radius: var(--content-switch-border-radius);
     border-end-end-radius: var(--content-switch-border-radius);
     border-inline-end: convert.to-rem(1px) solid cv.get-var('border-inverse');
   }
 
-  .#{$prefix}-content-switch__tab {
+  .r-content-switch__tab {
     @include type.type-style('body-01-compact');
     border-radius: 0;
     align-items: center;
@@ -54,18 +53,18 @@
     white-space: nowrap;
   }
 
-  .#{$prefix}-content-switch__tab:not(.#{$prefix}-content-switch__tab--selected):hover {
+  .r-content-switch__tab:not(.r-content-switch__tab--selected):hover {
     cursor: pointer;
     color: cv.get-var('text-primary');
   }
 
-  .#{$prefix}-content-switch__tab:not(.#{$prefix}-content-switch__tab--selected):hover,
-  .#{$prefix}-content-switch__tab:not(.#{$prefix}-content-switch__tab--selected):active {
+  .r-content-switch__tab:not(.r-content-switch__tab--selected):hover,
+  .r-content-switch__tab:not(.r-content-switch__tab--selected):active {
     background-color: cv.get-var('layer-hover');
     color: cv.get-var('text-primary');
   }
 
-  .#{$prefix}-content-switch__tab-label {
+  .r-content-switch__tab-label {
     display: inline-flex;
     overflow: hidden;
     max-inline-size: 100%;
@@ -74,7 +73,7 @@
   }
 
   /// Selected state
-  .#{$prefix}-content-switch__tab--selected {
+  .r-content-switch__tab--selected {
     background-color: cv.get-var('layer-selected-inverse');
     color: cv.get-var('text-inverse');
   }

--- a/packages/styles/scss/components/copy-button.scss
+++ b/packages/styles/scss/components/copy-button.scss
@@ -1,8 +1,7 @@
-@use '../config.scss' as *;
 @use '../utilities/custom-properties.scss' as cv;
 
 @layer components {
-  .#{$prefix}-copy-btn {
+  .r-copy-btn {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/packages/styles/scss/components/definition-list.scss
+++ b/packages/styles/scss/components/definition-list.scss
@@ -1,9 +1,8 @@
-@use '../config.scss' as *;
 @use '../type/styles.scss' as *;
 @use '../utilities/custom-properties.scss' as cv;
 
 @layer components {
-  .#{$prefix}-dl {
+  .r-dl {
     margin: 0;
     inline-size: 100%;
 
@@ -21,13 +20,13 @@
     }
   }
 
-  .#{$prefix}-dl__term {
+  .r-dl__term {
     margin: 0;
     @include type-style('label-02');
     color: cv.get-var('text-secondary');
   }
 
-  .#{$prefix}-dl__description {
+  .r-dl__description {
     font-style: normal;
     margin: 0;
     @include type-style('body-01-compact');

--- a/packages/styles/scss/components/icon-indicator.scss
+++ b/packages/styles/scss/components/icon-indicator.scss
@@ -1,11 +1,10 @@
-@use '../config.scss' as *;
 @use '../utilities/custom-properties.scss' as *;
 @use '../utilities/convert.scss';
 @use '../type/styles.scss' as type;
 @use '../type/font-family.scss' as ff;
 
 @layer components {
-  .#{$prefix}-icon-indicator {
+  .r-icon-indicator {
     --icon-color: #{get-var('icon-secondary')};
     --icon-size: #{convert.to-rem(16px)};
     display: flex;
@@ -25,45 +24,45 @@
     }
   }
 
-  .#{$prefix}-icon-indicator--sm {
+  .r-icon-indicator--sm {
     --icon-size: #{convert.to-rem(16px)};
     @include type.type-style('label-01');
   }
 
-  .#{$prefix}-icon-indicator--md {
+  .r-icon-indicator--md {
     --icon-size: #{convert.to-rem(20px)};
     @include type.type-style('label-02');
   }
 
-  .#{$prefix}-icon-indicator--lg {
+  .r-icon-indicator--lg {
     --icon-size: #{convert.to-rem(24px)};
     @include type.type-style('body-02');
   }
 
-  .#{$prefix}-icon-indicator--failed {
+  .r-icon-indicator--failed {
     --icon-color: #{get-var('support-error')};
   }
 
-  .#{$prefix}-icon-indicator--caution-major {
+  .r-icon-indicator--caution-major {
     --icon-color: #{get-var('support-caution-major')};
   }
 
-  .#{$prefix}-icon-indicator--caution-minor {
+  .r-icon-indicator--caution-minor {
     --icon-color: #{get-var('support-caution-minor')};
   }
 
-  .#{$prefix}-icon-indicator--undefined {
+  .r-icon-indicator--undefined {
     --icon-color: #{get-var('support-caution-undefined')};
   }
 
-  .#{$prefix}-icon-indicator--succeeded {
+  .r-icon-indicator--succeeded {
     --icon-color: #{get-var('support-success')};
   }
 
-  .#{$prefix}-icon-indicator--normal,
-  .#{$prefix}-icon-indicator--in-progress,
-  .#{$prefix}-icon-indicator--incomplete,
-  .#{$prefix}-icon-indicator--informative {
+  .r-icon-indicator--normal,
+  .r-icon-indicator--in-progress,
+  .r-icon-indicator--incomplete,
+  .r-icon-indicator--informative {
     --icon-color: #{get-var('support-info')};
   }
 }

--- a/packages/styles/scss/components/metrics-card.scss
+++ b/packages/styles/scss/components/metrics-card.scss
@@ -1,5 +1,4 @@
 @use 'sass:map';
-@use '../config.scss' as c;
 @use '../utilities/custom-properties.scss' as cv;
 
 $card-colors: (
@@ -8,53 +7,53 @@ $card-colors: (
   'selectColor': cv.get-var('layer'),
 );
 
-.#{c.$prefix}-metrics-card {
-    padding: 0.75rem;
+.r-metrics-card {
+  padding: 0.75rem;
+  width: 100%;
+  max-width: 26rem;
+  min-height: 10rem;
+  gap: 0.5rem;
+
+  &__container {
+    display: flex;
+    flex-direction: row;
+  }
+
+  &__content {
+    display: flex;
+    justify-content: space-between;
     width: 100%;
-    max-width: 26rem;
-    min-height: 10rem;
-    gap: 0.5rem;
+  }
 
-    &__container {
-        display: flex;
-        flex-direction: row;
-    }
+  &__textContent {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
 
-    &__content {
-        display: flex;
-        justify-content: space-between;
-        width: 100%;
+    & > * {
+      margin: 0;
     }
+  }
 
-    &__textContent {
-        display: flex;
-        flex-direction: column;
-        gap: 0.25rem;
+  &__linkText {
+    width: fit-content;
 
-        & > * {
-            margin: 0;
-        }
+    &:hover {
+      text-decoration: underline;
     }
+  }
 
-    &__linkText {
-        width: fit-content;
-    
-        &:hover {
-            text-decoration: underline;
-        }
+  &__remove-button {
+    color: map.get($card-colors, 'red');
+    transition: color 0.2s ease-in-out;
+    height: fit-content;
+
+    &:hover {
+      color: map.get($card-colors, 'hoverRed');
     }
-    
-    &__remove-button {
-        color: map.get($card-colors, 'red');
-        transition: color 0.2s ease-in-out;
-        height: fit-content;
-    
-        &:hover {
-            color: map.get($card-colors, 'hoverRed');
-        }
-    }
-    
-    select {
-        background-color: map.get($card-colors, 'selectColor'); 
-    }
+  }
+
+  select {
+    background-color: map.get($card-colors, 'selectColor');
+  }
 }

--- a/packages/styles/scss/components/metrics-wheel.scss
+++ b/packages/styles/scss/components/metrics-wheel.scss
@@ -1,5 +1,4 @@
 @use 'sass:map';
-@use '../config.scss' as c;
 @use '../utilities/custom-properties.scss' as cv;
 
 $metric-colors: (
@@ -14,7 +13,7 @@ $metric-colors: (
 );
 
 @layer components {
-  .#{c.$prefix}-metrics-wheel {
+  .r-metrics-wheel {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/packages/styles/scss/components/pagination.scss
+++ b/packages/styles/scss/components/pagination.scss
@@ -1,11 +1,10 @@
-@use '../config.scss' as *;
 @use '../type/styles.scss' as types;
 @use '../utilities/custom-properties.scss' as cv;
 @use '../utilities/convert.scss';
 @use '../layout';
 
 @layer components {
-  .#{$prefix}-pagination {
+  .r-pagination {
     --pagination-border-radius: #{convert.to-rem(4px)};
     --pagination-item-size: #{layout.height('md')};
     display: flex;
@@ -21,42 +20,42 @@
     border-end-end-radius: var(--pagination-border-radius);
   }
 
-  .#{$prefix}-pagination__start,
-  .#{$prefix}-pagination__end {
+  .r-pagination__start,
+  .r-pagination__end {
     display: flex;
     align-items: center;
     block-size: 100%;
   }
 
-  .#{$prefix}-pagination__start {
+  .r-pagination__start {
     padding-inline-start: cv.get-var('spacing-05');
   }
 
-  .#{$prefix}-pagination__end {
+  .r-pagination__end {
     column-gap: cv.get-var('spacing-03');
   }
 
-  .#{$prefix}-pagination__items-range {
+  .r-pagination__items-range {
     color: cv.get-var('text-secondary');
   }
 
-  .#{$prefix}-pagination__page-size {
+  .r-pagination__page-size {
     display: flex;
     align-items: center;
     column-gap: cv.get-var('spacing-03');
     block-size: 100%;
   }
 
-  .#{$prefix}-pagination__controls {
+  .r-pagination__controls {
     display: flex;
   }
 
-  .#{$prefix}-pagination__text {
+  .r-pagination__text {
     display: inline-block;
     white-space: nowrap;
   }
 
-  .#{$prefix}-pagination__select {
+  .r-pagination__select {
     @include types.type-style('body-01-compact');
     display: flex;
     block-size: var(--pagination-item-size);
@@ -66,12 +65,12 @@
     padding-inline: cv.get-var('spacing-02');
   }
 
-  .#{$prefix}-pagination__btn {
+  .r-pagination__btn {
     --btn-height: var(--pagination-item-size);
     border-radius: 0;
   }
 
-  .#{$prefix}-pagination__controls .#{$prefix}-pagination__btn:last-child {
+  .r-pagination__controls .r-pagination__btn:last-child {
     border-inline-start: 1px solid cv.get-var('border-subtle');
     border-start-start-radius: 0;
     border-start-end-radius: 0;
@@ -79,7 +78,7 @@
     border-end-end-radius: var(--pagination-border-radius);
   }
 
-  .#{$prefix}-pagination__btn:hover:not([disabled]) {
+  .r-pagination__btn:hover:not([disabled]) {
     background: cv.get-var('layer-hover');
   }
 }

--- a/packages/styles/scss/components/search.scss
+++ b/packages/styles/scss/components/search.scss
@@ -1,4 +1,3 @@
-@use '../config.scss' as *;
 @use '../type/styles.scss' as type;
 @use '../utilities/custom-properties.scss' as cv;
 @use '../utilities/visually-hidden.scss' as vh;
@@ -8,7 +7,7 @@
 @use '../utilities/component-reset.scss' as cr;
 
 @layer components {
-  .#{$prefix}-search {
+  .r-search {
     --search-inline-padding: #{cv.get-var('spacing-08')};
     --search-block-padding: 0;
     --search-height: #{layout.height('md')};
@@ -20,11 +19,11 @@
     inline-size: 100%;
   }
 
-  .#{$prefix}-search .#{$prefix}-label {
+  .r-search .r-label {
     @include vh.visually-hidden;
   }
 
-  .#{$prefix}-search__input {
+  .r-search__input {
     @include cr.reset();
     @include type.type-style('body-01-compact');
     order: 1;
@@ -53,20 +52,20 @@
   }
 
   /// Set size of icons
-  .#{$prefix}-search__magnifier,
-  .#{$prefix}-search__magnifier-icon,
-  .#{$prefix}-search__close-icon {
+  .r-search__magnifier,
+  .r-search__magnifier-icon,
+  .r-search__close-icon {
     block-size: var(--search-icon-size);
     inline-size: var(--search-icon-size);
   }
 
-  .#{$prefix}-search__magnifier-icon,
-  .#{$prefix}-search__close-icon {
+  .r-search__magnifier-icon,
+  .r-search__close-icon {
     color: currentColor;
   }
 
   /// Search icon
-  .#{$prefix}-search__magnifier {
+  .r-search__magnifier {
     position: absolute;
     z-index: 2;
     color: cv.get-var('icon-secondary');
@@ -77,7 +76,7 @@
   }
 
   /// Close icon
-  .#{$prefix}-search__close {
+  .r-search__close {
     @include cr.button-reset();
     display: flex;
     align-items: center;
@@ -92,13 +91,13 @@
     inline-size: var(--search-height);
   }
 
-  .#{$prefix}-search__close--hidden {
+  .r-search__close--hidden {
     opacity: 0;
     visibility: hidden;
   }
 
   /// Disabled
-  .#{$prefix}-search__input[disabled] {
+  .r-search__input[disabled] {
     background-color: cv.get-var('field');
     border-block-end: 1px solid transparent;
     color: cv.get-var('text-disabled');
@@ -110,17 +109,17 @@
   }
 
   /// Size variants
-  .#{$prefix}-search--sm {
+  .r-search--sm {
     --search-inline-padding: #{cv.get-var('spacing-07')};
     --search-block-padding: 0;
     --search-height: #{layout.height('sm')};
   }
-  .#{$prefix}-search--md {
+  .r-search--md {
     --search-inline-padding: #{cv.get-var('spacing-08')};
     --search-block-padding: 0;
     --search-height: #{layout.height('md')};
   }
-  .#{$prefix}-search--lg {
+  .r-search--lg {
     --search-inline-padding: #{cv.get-var('spacing-09')};
     --search-block-padding: 0;
     --search-height: #{layout.height('lg')};

--- a/packages/styles/scss/components/stack.scss
+++ b/packages/styles/scss/components/stack.scss
@@ -1,10 +1,9 @@
-@use '../config.scss' as *;
 @use '../utilities/custom-properties.scss' as *;
 @use '../utilities/convert.scss';
 @use '../spacing.scss';
 
 @layer components {
-  .#{$prefix}-stack {
+  .r-stack {
     &--vertical {
       display: grid;
       grid-auto-flow: row;

--- a/packages/styles/scss/components/table.scss
+++ b/packages/styles/scss/components/table.scss
@@ -1,4 +1,3 @@
-@use '../config.scss' as *;
 @use '../utilities/custom-properties.scss' as *;
 @use '../utilities/convert.scss';
 @use '../type/styles.scss' as type;
@@ -6,7 +5,7 @@
 
 @layer components {
   /* Default table styles */
-  .#{$prefix}-table-container {
+  .r-table-container {
     --table-background: transparent;
     --table-border-radius: #{convert.to-rem(4px)};
     display: grid;
@@ -19,7 +18,7 @@
     column-gap: get-var('spacing-03');
   }
 
-  .#{$prefix}-table__masthead {
+  .r-table__masthead {
     grid-area: masthead;
     background-color: var(--table-background);
     padding-block: get-var('spacing-05') 1.5rem;
@@ -28,20 +27,20 @@
     border-top-right-radius: var(--table-border-radius);
   }
 
-  .#{$prefix}-table__title {
+  .r-table__title {
     @include type.type-style('heading-03');
     margin: 0;
     color: get-var('text-primary');
     align-self: center;
   }
 
-  .#{$prefix}-table__subtitle {
+  .r-table__subtitle {
     @include type.type-style('body-01');
     margin: 0;
     color: get-var('text-secondary');
   }
 
-  .#{$prefix}-table__toolbar {
+  .r-table__toolbar {
     background-color: var(--table-background);
     display: flex;
     column-gap: get-var('spacing-03');
@@ -49,25 +48,25 @@
     grid-area: toolbar;
   }
 
-  .#{$prefix}-table-overflow {
+  .r-table-overflow {
     position: relative;
     grid-area: table;
     overflow: auto;
   }
 
   /// If the table has a title, set a background color
-  .#{$prefix}-table-container:has(.#{$prefix}-table__title) {
+  .r-table-container:has(.r-table__title) {
     --table-background: #{get-var('layer')};
   }
 
   /// if the table has a title, add some padding to the toolbar
-  .#{$prefix}-table-container:has(.#{$prefix}-table__title) .#{$prefix}-table__toolbar {
+  .r-table-container:has(.r-table__title) .r-table__toolbar {
     padding-inline: get-var('spacing-05');
     padding-block-end: get-var('spacing-05');
   }
 
   /// if the table has a title, remove border from search input
-  .#{$prefix}-table-container:has(.#{$prefix}-table__title) .#{$prefix}-table__toolbar-search .r-search__input {
+  .r-table-container:has(.r-table__title) .r-table__toolbar-search .r-search__input {
     border: 0 none;
     background: transparent;
   }
@@ -76,22 +75,19 @@
   /// - when the input is active and not disabled
   /// - when the input is not placeholder-shown
   /// - when the input is hovered and not disabled
-  .#{$prefix}-table-container:has(.#{$prefix}-table__title) .r-search__input:active:not([disabled]),
-  .#{$prefix}-table-container:has(.#{$prefix}-table__title) .r-search__input:not(:placeholder-shown),
-  .#{$prefix}-table-container:has(.#{$prefix}-table__title)
-    .#{$prefix}-table__toolbar-search
-    .r-search__input:hover:not([disabled]) {
+  .r-table-container:has(.r-table__title) .r-search__input:active:not([disabled]),
+  .r-table-container:has(.r-table__title) .r-search__input:not(:placeholder-shown),
+  .r-table-container:has(.r-table__title) .r-table__toolbar-search .r-search__input:hover:not([disabled]) {
     background: get-var('field-hover');
   }
 
   /// If the table don't have a title BUT does have a toolbar, add some margin between the toolbar and the table
-  .#{$prefix}-table-container:not(:has(.#{$prefix}-table__title)):has(.#{$prefix}-table__toolbar)
-    .#{$prefix}-table-overflow {
+  .r-table-container:not(:has(.r-table__title)):has(.r-table__toolbar) .r-table-overflow {
     margin-block-start: get-var('spacing-05');
   }
 
   /* Table -------------------------------------------------------------------- */
-  .#{$prefix}-table {
+  .r-table {
     --table-cell-x-padding: var(--cell-padding-inline, #{get-var('spacing-04')});
     --table-cell-y-padding: var(--cell-padding-block, #{get-var('spacing-03')});
     --table-cell-padding: var(--table-cell-y-padding) var(--table-cell-x-padding);
@@ -118,109 +114,109 @@
     }
   }
 
-  .#{$prefix}-table__header,
-  .#{$prefix}-table__cell {
+  .r-table__header,
+  .r-table__cell {
     display: flex;
     padding: var(--table-cell-padding);
     text-align: start;
     align-items: center;
   }
 
-  .#{$prefix}-table__header:where([data-cell-align='end']),
-  .#{$prefix}-table__cell:where([data-cell-align='end']) {
+  .r-table__header:where([data-cell-align='end']),
+  .r-table__cell:where([data-cell-align='end']) {
     display: flex;
     text-align: end;
     justify-content: flex-end;
   }
 
-  .#{$prefix}-table__header[data-cell-align='end'] .#{$prefix}-table__sort-btn {
+  .r-table__header[data-cell-align='end'] .r-table__sort-btn {
     display: flex;
     flex-direction: row-reverse;
   }
 
   /* Border radius */
-  .#{$prefix}-table__head .#{$prefix}-table__row:first-of-type .#{$prefix}-table__header:first-child {
+  .r-table__head .r-table__row:first-of-type .r-table__header:first-child {
     border-top-left-radius: var(--table-border-radius);
   }
 
-  .#{$prefix}-table__head .#{$prefix}-table__row:first-of-type .#{$prefix}-table__header:last-child {
+  .r-table__head .r-table__row:first-of-type .r-table__header:last-child {
     border-top-right-radius: var(--table-border-radius);
   }
 
-  .#{$prefix}-table-container:not(.#{$prefix}-table-container--with-pagination)
-    .#{$prefix}-table
-    .#{$prefix}-table__body
-    .#{$prefix}-table__row:last-of-type
-    .#{$prefix}-table__cell:first-child {
+  .r-table-container:not(.r-table-container--with-pagination)
+    .r-table
+    .r-table__body
+    .r-table__row:last-of-type
+    .r-table__cell:first-child {
     border-bottom-left-radius: var(--table-border-radius);
   }
 
-  .#{$prefix}-table-container:not(.#{$prefix}-table-container--with-pagination)
-    .#{$prefix}-table
-    .#{$prefix}-table__body
-    .#{$prefix}-table__row:last-of-type
-    .#{$prefix}-table__cell:last-child {
+  .r-table-container:not(.r-table-container--with-pagination)
+    .r-table
+    .r-table__body
+    .r-table__row:last-of-type
+    .r-table__cell:last-child {
     border-bottom-right-radius: var(--table-border-radius);
   }
 
   /* Table header */
-  .#{$prefix}-table__header {
+  .r-table__header {
     color: get-var('text-primary');
     background-color: get-var('layer-accent');
     font-weight: ff.font-weight('semibold');
   }
 
-  .#{$prefix}-table__header:where([aria-sort='descending']),
-  .#{$prefix}-table__header:where([aria-sort='ascending']) {
+  .r-table__header:where([aria-sort='descending']),
+  .r-table__header:where([aria-sort='ascending']) {
     color: get-var('text-primary');
     background-color: get-var('layer-selected-hover');
   }
 
-  .#{$prefix}-table__header:hover:has(.#{$prefix}-table__sort-btn),
-  .#{$prefix}-table__header:hover:has(.#{$prefix}-table__sort-btn) {
+  .r-table__header:hover:has(.r-table__sort-btn),
+  .r-table__header:hover:has(.r-table__sort-btn) {
     background-color: get-var('layer-selected-hover');
   }
 
   /* Table body */
-  .#{$prefix}-table__body {
+  .r-table__body {
   }
 
   /* Table cell */
-  .#{$prefix}-table__cell {
+  .r-table__cell {
     background-color: get-var('layer');
   }
 
-  .#{$prefix}-table .#{$prefix}-table__body .#{$prefix}-table__row:not(:last-of-type) .#{$prefix}-table__cell {
+  .r-table .r-table__body .r-table__row:not(:last-of-type) .r-table__cell {
     border-bottom: 1px solid get-var('border-subtle');
   }
 
   /* Control visibility of sort icons */
-  .#{$prefix}-table__sort-icon {
+  .r-table__sort-icon {
     width: convert.to-rem(20px);
     height: convert.to-rem(20px);
     visibility: hidden;
   }
 
   /* The sort icon is visible if the header is sortable and is hovered or focused */
-  .#{$prefix}-table__header:hover .#{$prefix}-table__sort-icon,
-  .#{$prefix}-table__header .#{$prefix}-table__sort-btn:focus .#{$prefix}-table__sort-icon {
+  .r-table__header:hover .r-table__sort-icon,
+  .r-table__header .r-table__sort-btn:focus .r-table__sort-icon {
     visibility: visible;
   }
 
   /* Each sort icon is visible if the TableHeader is currently in the corresponding sort state */
-  .#{$prefix}-table__header[aria-sort='ascending'] .#{$prefix}-table__sort-icon--ascending,
-  .#{$prefix}-table__header[aria-sort='descending'] .#{$prefix}-table__sort-icon--descending {
+  .r-table__header[aria-sort='ascending'] .r-table__sort-icon--ascending,
+  .r-table__header[aria-sort='descending'] .r-table__sort-icon--descending {
     visibility: visible;
   }
 
-  .#{$prefix}-table__cell:where([scope='row']) {
+  .r-table__cell:where([scope='row']) {
     display: flex;
     font-weight: ff.font-weight('semibold');
     color: get-var('text-primary');
     align-items: center;
   }
 
-  .#{$prefix}-table__sort-btn {
+  .r-table__sort-btn {
     --btn-height: auto;
     padding: 0;
     border: 0 none;
@@ -240,16 +236,16 @@
   }
 
   /* Grid layout */
-  .#{$prefix}-table__head,
-  .#{$prefix}-table__body,
-  .#{$prefix}-table__row {
+  .r-table__head,
+  .r-table__body,
+  .r-table__row {
     display: contents;
   }
 
   @supports (grid-template-columns: subgrid) {
-    .#{$prefix}-table__head,
-    .#{$prefix}-table__body,
-    .#{$prefix}-table__row {
+    .r-table__head,
+    .r-table__body,
+    .r-table__row {
       display: grid;
       grid-template-columns: subgrid;
       grid-column: -1 /1;

--- a/packages/styles/scss/components/tag.scss
+++ b/packages/styles/scss/components/tag.scss
@@ -1,5 +1,4 @@
 @use 'sass:map';
-@use '../config.scss' as *;
 @use '../utilities/custom-properties.scss' as *;
 @use '../utilities/convert.scss';
 @use '../spacing.scss' as spacing;
@@ -27,7 +26,7 @@ $sizes: (
   ),
 );
 
-.#{$prefix}-tag {
+.r-tag {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -48,19 +47,19 @@ $sizes: (
       height: map.get($values, 'height');
       padding: 0 map.get($values, 'xPadding');
 
-      &.#{$prefix}-tag--dismissible {
+      &.r-tag--dismissible {
         padding-right: map.get($values, 'crossPaddingRight');
       }
 
-      .#{$prefix}-tag__remove-icon {
+      .r-tag__remove-icon {
         margin-left: map.get($values, 'xPadding');
       }
 
-      &.#{$prefix}-tag--has-icon {
+      &.r-tag--has-icon {
         padding-left: map.get($values, 'iconMargin');
       }
 
-      .#{$prefix}-tag__icon-container {
+      .r-tag__icon-container {
         margin-right: map.get($values, 'iconMargin');
       }
     }

--- a/packages/styles/scss/components/tile.scss
+++ b/packages/styles/scss/components/tile.scss
@@ -1,9 +1,8 @@
-@use '../config.scss' as *;
 @use '../type/styles.scss' as types;
 @use '../utilities/custom-properties.scss' as cv;
 
 @layer components {
-  .#{$prefix}-tile {
+  .r-tile {
     @include types.type-style('body-01');
     position: relative;
     display: block;
@@ -15,12 +14,12 @@
     border-radius: 0.25rem;
   }
 
-  .#{$prefix}-tile--clickable {
+  .r-tile--clickable {
     cursor: pointer;
     border: 1px solid cv.get-var('border-tile');
   }
 
-  .#{$prefix}-tile--clickable:hover {
+  .r-tile--clickable:hover {
     background-color: cv.get-var('layer-hover');
   }
 }

--- a/packages/styles/scss/components/tooltip.scss
+++ b/packages/styles/scss/components/tooltip.scss
@@ -1,9 +1,8 @@
-@use '../config.scss' as *;
 @use '../type/styles.scss' as types;
 @use '../utilities/custom-properties.scss' as cv;
 
 @layer components {
-  .#{$prefix}-tooltip {
+  .r-tooltip {
     --r-tooltip-shadow:
       0 0 1px var(--r-tooltip-shadow-color-default, #05050629),
       0 0 2px var(--r-tooltip-shadow-color-default, #05050629),

--- a/packages/styles/scss/config.scss
+++ b/packages/styles/scss/config.scss
@@ -1,9 +1,3 @@
-/// The namespace of all classes and css-variables in the codebase.
-/// @access public
-/// @type String
-/// @group config
-$prefix: 'r' !default;
-
 /// If true, include reset CSS
 /// @access public
 /// @type Bool

--- a/packages/styles/scss/css-variables/variables.scss
+++ b/packages/styles/scss/css-variables/variables.scss
@@ -1,6 +1,5 @@
 @use 'sass:map';
 @use 'sass:meta';
-@use '../config' as *;
 @use '../colors/theme' as *;
 @use '../spacing' as spacing;
 @use '../utilities/custom-properties.scss' as cv;

--- a/packages/styles/scss/layer.scss
+++ b/packages/styles/scss/layer.scss
@@ -1,9 +1,9 @@
-@use 'config.scss' as *;
+@use 'config.scss' as config;
 @use './utilities/custom-properties.scss' as *;
 
 @mixin emit-layer-custom-properties {
   :root,
-  .#{$prefix}-layer--one {
+  .r-layer--one {
     @include declaration('layer', get-var('layer-01'));
     @include declaration('layer-active', get-var('layer-active-01'));
     @include declaration('layer-hover', get-var('layer-hover-01'));
@@ -20,7 +20,7 @@
     @include declaration('border-tile', get-var('border-tile-01'));
   }
 
-  .#{$prefix}-layer--two {
+  .r-layer--two {
     @include declaration('layer', get-var('layer-02'));
     @include declaration('layer-active', get-var('layer-active-02'));
     @include declaration('layer-hover', get-var('layer-hover-02'));
@@ -37,7 +37,7 @@
     @include declaration('border-tile', get-var('border-tile-02'));
   }
 
-  .#{$prefix}-layer--three {
+  .r-layer--three {
     @include declaration('layer', get-var('layer-03'));
     @include declaration('layer-active', get-var('layer-active-03'));
     @include declaration('layer-hover', get-var('layer-hover-03'));
@@ -55,7 +55,7 @@
   }
 }
 
-@if $css--layer-tokens == true {
+@if config.$css--layer-tokens == true {
   @layer base {
     @include emit-layer-custom-properties;
   }

--- a/packages/styles/scss/type/styles.scss
+++ b/packages/styles/scss/type/styles.scss
@@ -131,7 +131,7 @@ $tokens: (
 
 @mixin emit-custom-properties($name, $value) {
   @each $property, $value in $value {
-    #{$property}: var(--#{config.$prefix}-#{$name}-#{$property}, #{$value});
+    #{$property}: var(--r-#{$name}-#{$property}, #{$value});
   }
 }
 

--- a/packages/styles/scss/utilities/custom-properties.scss
+++ b/packages/styles/scss/utilities/custom-properties.scss
@@ -25,16 +25,16 @@
 /// @example get-var('text-primary') gives var(--r-text-primary)
 @function get-var($name, $fallback: false) {
   @if $fallback {
-    @return var(--#{config.$prefix}-#{$name}, #{$fallback});
+    @return var(--r-#{$name}, #{$fallback});
   }
-  @return var(--#{config.$prefix}-#{$name});
+  @return var(--r-#{$name});
 }
 
 /// Get the <custom-property-name> for a given string
 /// @param {String} $name
 /// @returns {String}
 @function get-name($name) {
-  @return --#{config.$prefix}-#{$name};
+  @return --r-#{$name};
 }
 
 /// Emit a declaration which sets the value of a CSS Custom Property using the

--- a/packages/styles/scss/utilities/visually-hidden.scss
+++ b/packages/styles/scss/utilities/visually-hidden.scss
@@ -1,5 +1,3 @@
-@use '../config' as *;
-
 @mixin visually-hidden {
   position: absolute;
   overflow: hidden;
@@ -13,6 +11,6 @@
   white-space: nowrap;
 }
 
-.#{$prefix}--visually-hidden {
+.r--visually-hidden {
   @include visually-hidden;
 }

--- a/turbo/generators/templates/component.scss.hbs
+++ b/turbo/generators/templates/component.scss.hbs
@@ -1,9 +1,8 @@
-@use '../config.scss' as *;
 @use '../type/styles.scss' as types;
 @use '../utilities/custom-properties.scss' as cv;
 
 @layer components {
-  .#{$prefix}-{{dashCase name}} {
+  .r-{{dashCase name}} {
     // Add your styles here
   }
 }


### PR DESCRIPTION
This pull request refactors the `styles` library by removing the prefix configuration. 

The prefix was meant to tackle a situation where there would be a naming conflict with any other design library or system being used. However the risk of that happening is very low, while implementing the prefix constantly adds a tiny bit of overhead. Therefore I see that we can just make it simpler by removing it. Should there ever be a need for a prefix in the future at least we know it is possible. 