### PR TITLE
feat(web): add v2 ingresses to cluster

### DIFF
--- a/apps/web/__mocks__/data/clusters.ts
+++ b/apps/web/__mocks__/data/clusters.ts
@@ -1,4 +1,5 @@
 import { sub } from 'date-fns'
+import { faker } from '@faker-js/faker'
 
 export const clustersVersion1 = [
   {
@@ -43,7 +44,7 @@ export const clustersVersion1 = [
     },
     topology: {
       controlPlaneEndpoint: '',
-      egressIp: '10.11.63.5',
+      egressIp: faker.internet.ipv4(),
       controlPlane: {
         nodes: null,
         metrics: {
@@ -171,11 +172,11 @@ export const clustersVersion1 = [
     workspaceId: '66792637962733bd96c8a2f6',
     workspace: {
       id: '66792637962733bd96c8a2f6',
-      name: 'trd1cl02-aaa-002-dev',
-      datacenterId: '64fb42853fc0553130aa26ea',
+      name: 'noe01-aaa-002-dev',
+      datacenterId: faker.string.uuid(),
       datacenter: {
-        id: '64fb42853fc0553130aa26ea',
-        name: 'trd1cl02',
+        id: faker.string.uuid(),
+        name: 'noe01',
         provider: 'tanzu',
         location: {
           id: '',
@@ -363,15 +364,15 @@ export const clustersVersion1 = [
     },
     ingresses: [
       {
-        uid: '4dd873a3-8b65-4e7f-aeea-332891cee31a',
+        uid: faker.string.uuid(),
         health: 1,
         name: 'argocd-server',
         namespace: 'argocd',
         class: 'avi-ingress-class-datacenter',
         ingressrules: [
           {
-            hostname: 'argo.aaa-002-dev.trd1cl02-aaa-002-dev.sky.example.com',
-            ipaddresses: ['10.204.28.113'],
+            hostname: 'argo.aaa-002-dev.noe01-aaa-002-dev.sky.example.com',
+            ipaddresses: [faker.internet.ipv4()],
             rules: [
               {
                 path: '/',
@@ -404,15 +405,15 @@ export const clustersVersion1 = [
         ],
       },
       {
-        uid: 'bbaf489b-d514-4087-9100-cc0777fc3dd8',
+        uid: faker.string.uuid(),
         health: 1,
         name: 'grafana-somenett',
         namespace: 'prometheus-operator',
         class: 'avi-ingress-class-datacenter',
         ingressrules: [
           {
-            hostname: 'grafana.aaa-002-dev.trd1cl02-aaa-002-dev.sky.example.com',
-            ipaddresses: ['10.204.28.113'],
+            hostname: 'grafana.aaa-002-dev.noe01-aaa-002-dev.sky.example.com',
+            ipaddresses: [faker.internet.ipv4()],
             rules: [
               {
                 path: '/',
@@ -462,9 +463,9 @@ export const clustersVersion1 = [
       },
     },
     metadata: {
-      projectId: '66794b1e4d60b4db3219372c',
+      projectId: faker.string.uuid(),
       project: {
-        id: '66794b1e4d60b4db3219372c',
+        id: faker.string.uuid(),
         name: 'aaa-002-dev',
         description: 'A project description',
         active: true,
@@ -529,5 +530,137 @@ export const clustersVersion1 = [
   },
 ]
 
-// TODO: Add data for this structure once it is more ready in the backend
-export const clustersVersion2 = []
+export const clustersVersion2 = {
+  resources: [
+    {
+      kind: 'KubernetesCluster',
+      apiVersion: 'general.ror.internal/v1alpha1',
+      metadata: {
+        name: 'aaa-001-dev',
+        creationTimestamp: '2022-03-17T14:06:47Z',
+      },
+      rormeta: {
+        version: 'v2',
+        ownerref: {
+          scope: 'workspace',
+          subject: 'trd1-nhn-mgmt',
+        },
+        tags: [
+          {
+            key: 'consumer',
+            value: 'ror',
+          },
+          {
+            key: 'environment',
+            value: 'dev',
+          },
+          {
+            key: 'criticality',
+            value: '4',
+          },
+          {
+            key: 'sensitivity',
+            value: '2',
+          },
+          {
+            key: 'servicetag',
+            value: '434423',
+          },
+        ],
+      },
+      kubernetescluster: {
+        spec: {
+          data: {
+            clusterId: 'aaa-001-dev-kgfh',
+            provider: 'tanzu',
+            datacenter: 'trd1',
+            region: 'trd',
+            zone: 'trd1cl01',
+            project: 'test',
+            workspace: 'trd1-nhn-mgmt',
+            workorder: 'Intern',
+            environment: 'dev',
+          },
+          topology: {
+            version: 'v1.28.7',
+            controlplane: {
+              replicas: 3,
+              provider: 'tanzu',
+              machineClass: 'best-effort-large',
+              metadata: {
+                labels: null,
+                annotations: null,
+              },
+              storage: null,
+            },
+            workers: {
+              nodePools: [
+                {
+                  name: 'default',
+                  replicas: 4,
+                  provider: 'tanzu',
+                  machineClass: 'best-effort-cpu-2xlarge',
+                  metadata: {
+                    labels: null,
+                    annotations: null,
+                  },
+                  storage: null,
+                },
+              ],
+            },
+          },
+        },
+        status: {
+          status: {
+            cluster: {
+              externalId: '0000-0000-0000-0000',
+              resources: [
+                {
+                  name: 'cpu',
+                  allocated: '8',
+                  usage: '8%',
+                },
+                {
+                  name: 'memory',
+                  allocated: '64Gi',
+                  usage: '50%',
+                },
+              ],
+              controlplane: {
+                status: 'Running',
+                message: '3/3 Controllplane is running',
+              },
+              workers: {
+                nodepools: [
+                  {
+                    name: 'default',
+                    status: 'Running',
+                    message: '4/4 Workers are running',
+                  },
+                ],
+              },
+            },
+            versions: [
+              {
+                component: 'kubernetes',
+                version: 'v1.28.7',
+              },
+              {
+                component: 'nhntooling',
+                version: 'v1.16.3',
+                branch: 'main',
+              },
+            ],
+            'egress-ip': '10.204.2.10',
+            controlplaneendpoint: '10.204.0.50:6443',
+            lastUpdated: '0001-01-01T00:00:00Z',
+            lastUpdatedBy: 'agentv2',
+            created: '2022-03-17T14:06:47Z',
+          },
+          phase: 'Running',
+          conditions: null,
+        },
+      },
+    },
+  ],
+}

--- a/apps/web/__mocks__/data/ingresses.ts
+++ b/apps/web/__mocks__/data/ingresses.ts
@@ -1,0 +1,79 @@
+import { faker } from '@faker-js/faker'
+
+export const ingressesResponse = {
+  resources: [
+    {
+      kind: 'Ingress',
+      apiVersion: 'networking.k8s.io/v1',
+      metadata: {
+        name: 'argocd-server',
+        namespace: 'argocd',
+        uid: faker.string.uuid(),
+        resourceVersion: faker.string.numeric(9),
+        generation: 1,
+        creationTimestamp: faker.date.past(),
+        labels: {},
+        annotations: {},
+        managedFields: [],
+      },
+      rormeta: {
+        version: 'v2',
+        hash: faker.string.numeric(19),
+        ownerref: {
+          scope: 'cluster',
+          subject: 'aaa-002-dev-9oz9',
+        },
+        action: 'Add',
+      },
+      ingress: {
+        spec: {
+          defaultBackend: {
+            resource: {},
+            service: {
+              port: {},
+            },
+          },
+          ingressClassName: 'avi-ingress-class-datacenter',
+          rules: [
+            {
+              apiGroup: '',
+              http: {
+                paths: [
+                  {
+                    backend: {
+                      resource: {},
+                      service: {
+                        name: 'argo-web',
+                        port: {
+                          number: 80,
+                        },
+                      },
+                    },
+                    path: '/',
+                    pathType: 'Prefix',
+                  },
+                ],
+              },
+            },
+          ],
+          tls: [
+            {
+              hosts: ['argo.aaa-002-dev.no-e.sky.example.com'],
+              secretName: 'argo-tls-test',
+            },
+          ],
+        },
+        status: {
+          loadBalancer: {
+            ingress: [
+              {
+                hostname: 'argo.aaa-002-dev.no-e.sky.example.com',
+                ip: faker.internet.ipv4(),
+              },
+            ],
+          },
+        },
+      },
+    },
+  ],
+}

--- a/apps/web/__mocks__/data/nodes.ts
+++ b/apps/web/__mocks__/data/nodes.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker'
 import { NodeResponse } from '@ror/js-api-client'
 
 const nodes: NodeResponse = {
@@ -7,8 +8,8 @@ const nodes: NodeResponse = {
       apiVersion: 'v1',
       metadata: {
         name: 't-aaa-001-control-plane-6ffkc',
-        uid: '3f346038-0136-4f0d-9aa6-3c277c37a14e',
-        resourceVersion: '493788292',
+        uid: faker.string.uuid(),
+        resourceVersion: faker.string.numeric(6),
         creationTimestamp: '2025-01-31T15:00:54Z',
         labels: {},
         annotations: {},
@@ -16,7 +17,7 @@ const nodes: NodeResponse = {
       },
       rormeta: {
         version: 'v2',
-        hash: '5884478303314410569',
+        hash: faker.string.numeric(10),
         ownerref: { scope: 'cluster', subject: 'aaa-001-dev' },
         action: 'Update',
       },
@@ -51,8 +52,8 @@ const nodes: NodeResponse = {
       apiVersion: 'v1',
       metadata: {
         name: 't-aaa-001-workers-f4jpw-f4hxf-h5g2n',
-        uid: '9408a85e-901c-48ec-bd4b-4de4a44c82be',
-        resourceVersion: '493788565',
+        uid: faker.string.uuid(),
+        resourceVersion: faker.string.numeric(6),
         creationTimestamp: '2025-01-31T15:14:58Z',
         labels: {},
         annotations: {},
@@ -60,7 +61,7 @@ const nodes: NodeResponse = {
       },
       rormeta: {
         version: 'v2',
-        hash: '2592243034891482106',
+        hash: faker.string.numeric(10),
         ownerref: { scope: 'cluster', subject: 'aaa-001-dev' },
         action: 'Update',
       },
@@ -95,8 +96,8 @@ const nodes: NodeResponse = {
       apiVersion: 'v1',
       metadata: {
         name: 't-aaa-001-workers-f4jpw-f4hxf-lmcrl',
-        uid: '4a4ceb1e-0131-47a5-b566-4ed2d5f2f07f',
-        resourceVersion: '493782257',
+        uid: faker.string.uuid(),
+        resourceVersion: faker.string.numeric(6),
         creationTimestamp: '2025-01-31T15:10:22Z',
         labels: {},
         annotations: {},
@@ -104,7 +105,7 @@ const nodes: NodeResponse = {
       },
       rormeta: {
         version: 'v2',
-        hash: '2412552037763072509',
+        hash: faker.string.numeric(19),
         ownerref: { scope: 'cluster', subject: 'aaa-001-dev' },
         action: 'Update',
       },
@@ -139,8 +140,8 @@ const nodes: NodeResponse = {
       apiVersion: 'v1',
       metadata: {
         name: 't-aaa-001-workers-f4jpw-f4hxf-w2mhs',
-        uid: '3d70c520-1a20-4d38-b1dc-1200381ee7bf',
-        resourceVersion: '493788829',
+        uid: faker.string.uuid(),
+        resourceVersion: faker.string.numeric(6),
         creationTimestamp: '2025-01-31T15:06:54Z',
         labels: {},
         annotations: {},
@@ -148,7 +149,7 @@ const nodes: NodeResponse = {
       },
       rormeta: {
         version: 'v2',
-        hash: '4944169613020978094',
+        hash: faker.string.numeric(19),
         ownerref: { scope: 'cluster', subject: 'aaa-001-dev' },
         action: 'Update',
       },

--- a/apps/web/__mocks__/handlers/v2-resources.ts
+++ b/apps/web/__mocks__/handlers/v2-resources.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from 'msw'
 import { clustersVersion2 } from '../data/clusters'
 import nodes from '../data/nodes'
+import { ingressesResponse } from '../data/ingresses'
 
 export const v2ResourcesHandlers = [
   http.get('http://localhost:10000/v2/resources', ({ request }) => {
@@ -14,6 +15,8 @@ export const v2ResourcesHandlers = [
         return HttpResponse.json(clustersVersion2)
       case 'Node':
         return HttpResponse.json(nodes)
+      case 'Ingress':
+        return HttpResponse.json(ingressesResponse)
       default:
         return HttpResponse.json(null)
     }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next dev --turbopack -p 11100",
+    "dev": "next dev -p 11100",
     "build": "next build",
     "build:github": "env-cmd -f .env.github-workflow next build",
     "start": "next start",
@@ -43,6 +43,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@faker-js/faker": "9.6.0",
     "@tailwindcss/postcss": "^4.0.0",
     "@types/node": "^22.12.0",
     "@types/react": "19.0.11",

--- a/apps/web/src/app/(protected)/clusters/[id]/ingresses/ingress-data-view.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/ingresses/ingress-data-view.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { DataView } from '@/components/ui/data-view'
+import type { Ingress } from '@ror/js-api-client'
+import { ColumnDef, createColumnHelper, getCoreRowModel, getSortedRowModel, useReactTable } from '@tanstack/react-table'
+import { ExternalLink } from 'lucide-react'
+
+const columnHelper = createColumnHelper<Ingress>()
+
+const columns = [
+  columnHelper.accessor('metadata.name', {
+    id: 'name',
+    header: 'Name',
+  }),
+  columnHelper.accessor('ingress.spec.ingressClassName', {
+    header: 'Infrastructure',
+    cell: (info) => {
+      const value = info.getValue()
+
+      if (value.endsWith('internett')) {
+        return <span>Internet</span>
+      } else if (value.endsWith('health')) {
+        return 'Helsenett'
+      } else if (value.endsWith('datacenter')) {
+        return 'Data center'
+      }
+
+      return <span>{value}</span>
+    },
+  }),
+  columnHelper.accessor('metadata.namespace', {
+    header: 'Namespace',
+  }),
+  columnHelper.display({
+    header: 'Hostname',
+    cell: (info) => {
+      const hostnames = info.row.original?.ingress.status.loadBalancer.ingress?.map((rule) => rule.hostname) || []
+
+      return (
+        <div className='flex flex-wrap gap-2'>
+          {hostnames.map((hostname) => (
+            <a
+              key={hostname}
+              href={`https://${hostname}`}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='flex items-center gap-2 text-link truncate'
+            >
+              <span>{hostname}</span>
+              <ExternalLink className='w-5 h-5 text-current shrink-0' />
+            </a>
+          ))}
+        </div>
+      )
+    },
+  }),
+  columnHelper.display({
+    header: 'IP Address',
+    cell: (info) => {
+      const ipAddresses = info.row.original?.ingress.status.loadBalancer.ingress?.map((rule) => rule.ip) || []
+      const lastIpAddress = ipAddresses.at(-1)
+
+      if (!lastIpAddress) {
+        return <div>Missing …</div>
+      }
+
+      return <span>{lastIpAddress}</span>
+    },
+  }),
+] as ColumnDef<Ingress>[]
+
+interface ClusterIngressesDataViewProps {
+  ingresses: Ingress[]
+}
+
+export function ClusterIngressesDataView({ ingresses }: ClusterIngressesDataViewProps) {
+  const table = useReactTable({
+    data: ingresses,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  })
+
+  return <DataView table={table} />
+}

--- a/apps/web/src/app/(protected)/clusters/[id]/ingresses/page.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/ingresses/page.tsx
@@ -1,5 +1,6 @@
 import { authGuard } from '@/features/auth/utils/auth-guard'
 import { rorApiClient } from '@/services/ror-api'
+import { ClusterIngressesDataView } from './ingress-data-view'
 
 interface ClusterIngressesPageProps {
   params: Promise<{
@@ -12,12 +13,22 @@ export default async function ClusterIngressesPage({ params }: ClusterIngressesP
 
   const session = await authGuard()
   const client = rorApiClient(session.accessToken)
-  const cluster = await client.kubernetesClusters.idV1(id)
-  const ingresses = cluster.ingresses
+
+  const ingressFilter = [
+    {
+      field: 'rormeta.ownerref.subject',
+      type: 'string',
+      operator: 'eq',
+      value: id,
+    },
+  ]
+  const listParams = new URLSearchParams([['filter', JSON.stringify(ingressFilter)]])
+  const clusterIngresses = await client.ingresses.list(listParams)
+  const ingresses = clusterIngresses?.resources ?? []
 
   if (!ingresses) {
     return <div>No ingresses found</div>
   }
 
-  return <h1>Ingresses</h1>
+  return <ClusterIngressesDataView ingresses={ingresses} />
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
         "zod": "^3.24.1"
       },
       "devDependencies": {
+        "@faker-js/faker": "9.6.0",
         "@tailwindcss/postcss": "^4.0.0",
         "@types/node": "^22.12.0",
         "@types/react": "19.0.11",
@@ -1362,6 +1363,23 @@
       "resolved": "https://registry.npmjs.org/@evilmartians/harmony/-/harmony-1.4.0.tgz",
       "integrity": "sha512-NgKkhTnQOSE07IvDxHHPLzFF81TaWU1Ir5nmaRM+PebXAol5vNXnk+Lp2JPgj1P/PBTu6lzSWckSpNjC19XSUw==",
       "license": "MIT"
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.6.0.tgz",
+      "integrity": "sha512-3vm4by+B5lvsFPSyep3ELWmZfE3kicDtmemVpuwl1yH7tqtnHdsA6hG8fbXedMVdkzgtvzWoRgjSB4Q+FHnZiw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
+      }
     },
     "node_modules/@floating-ui/core": {
       "version": "1.6.9",

--- a/packages/js-api-client/src/index.ts
+++ b/packages/js-api-client/src/index.ts
@@ -12,6 +12,7 @@ export type {
   Ingress,
   IngressResponse,
   Cluster,
+  ClusterIngress,
   ClustersResponse,
   KubernetesCluster,
   KubernetesClusterResponse,

--- a/packages/js-api-client/src/schemas/ingress.ts
+++ b/packages/js-api-client/src/schemas/ingress.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { createV2ResourceResponseSchema } from './common'
+import { createV2ResourceResponseSchema, V2ResourceSchema } from './common'
 
 const IngressSpecBackendResource = z.object({
   apiGroup: z.string().nullable().optional(),
@@ -29,7 +29,7 @@ const IngressSpecRulesHttpPathsSchema = z.object({
 })
 
 const IngressSpecRulesHttpSchema = z.object({
-  paths: IngressSpecRulesHttpPathsSchema.nullable().optional(),
+  paths: z.array(IngressSpecRulesHttpPathsSchema).nullable().optional(),
 })
 
 const IngressSpecRulesSchema = z.object({
@@ -62,7 +62,7 @@ const IngressStatusSchema = z.object({
   loadBalancer: IngressStatusLoadBalancerSchema,
 })
 
-export const IngressSchema = z.object({
+export const IngressSchema = V2ResourceSchema.extend({
   ingress: z.object({
     spec: IngressSpecSchema,
     status: IngressStatusSchema,

--- a/packages/js-api-client/src/schemas/kubernetes-cluster-v1.ts
+++ b/packages/js-api-client/src/schemas/kubernetes-cluster-v1.ts
@@ -79,6 +79,31 @@ const AclModel = z.object({
   accessGroups: z.array(z.string()),
 })
 
+const IngressRuleV1 = z
+  .object({
+    hostname: z.string().optional(),
+    ipaddresses: z.array(z.string()).optional(),
+    rules: z.array(
+      z.object({
+        path: z.string(),
+        // TODO: Finish model
+        service: z.object({}).passthrough(),
+      })
+    ),
+  })
+  .passthrough()
+
+export const ClusterIngressModelV1 = z.object({
+  uid: z.string(),
+  health: z.number(),
+  name: z.string(),
+  namespace: z.string(),
+  class: z.string(),
+  ingressrules: z.array(IngressRuleV1).optional(),
+})
+
+const ClusterIngressesModelV1 = z.array(ClusterIngressModelV1.passthrough())
+
 export const ClusterSchema = z
   .object({
     clusterId: z.string(),
@@ -107,26 +132,7 @@ export const ClusterSchema = z
     topology: TopologyModel,
     versions: VersionsModel,
     workspace: WorkspaceModel,
-    ingresses: z
-      .union([
-        z.array(
-          z
-            .object({
-              ingressrules: z
-                .array(
-                  z
-                    .object({
-                      hostname: z.string().optional(),
-                    })
-                    .optional()
-                )
-                .optional(),
-            })
-            .optional()
-        ),
-        z.null(),
-      ])
-      .optional(),
+    ingresses: ClusterIngressesModelV1.optional().nullable(),
     acl: AclModel,
   })
   .passthrough()

--- a/packages/js-api-client/src/services/ingresses.ts
+++ b/packages/js-api-client/src/services/ingresses.ts
@@ -1,10 +1,9 @@
 import type { RequestOptions } from '../core/request'
 import { validateResponse } from '../core/validation'
-import { createV2ResourceResponseSchema } from '../schemas/common'
 import { IngressResponseSchema, IngressSchema } from '../schemas/ingress'
 
 export const createIngressesService = (request: (requestOptions: RequestOptions) => Promise<unknown>) => ({
-  list: async (otherParams: URLSearchParams) => {
+  list: async (otherParams?: URLSearchParams) => {
     const params = new URLSearchParams(otherParams)
     params.set('apiversion', 'networking.k8s.io/v1')
     params.set('kind', 'Ingress')
@@ -14,8 +13,7 @@ export const createIngressesService = (request: (requestOptions: RequestOptions)
       path: '/v2/resources',
       params,
     })
-    const responseSchema = createV2ResourceResponseSchema(IngressResponseSchema)
-    return validateResponse(response, responseSchema)
+    return validateResponse(response, IngressResponseSchema)
   },
   byId: async (id: string) => {
     const response = await request({

--- a/packages/js-api-client/src/types/entities.ts
+++ b/packages/js-api-client/src/types/entities.ts
@@ -1,16 +1,17 @@
 import { z } from 'zod'
 import { IngressSchema, IngressResponseSchema } from '../schemas/ingress'
 import { KubernetesClusterSchema, KubernetesClusterResponseSchema } from '../schemas/kubernetes-cluster'
-import { ClusterSchema, ClustersResponseSchema } from '../schemas/kubernetes-cluster-v1'
+import { ClusterIngressModelV1, ClusterSchema, ClustersResponseSchema } from '../schemas/kubernetes-cluster-v1'
 import { NodeSchema, NodeResponseSchema } from '../schemas/node'
 import { UserSelfSchema } from '../schemas/user'
 
 export type Ingress = z.infer<typeof IngressSchema>
 export type IngressResponse = z.infer<typeof IngressResponseSchema>
-// Cluster matches the v1 endpoint
+// "Cluster" matches the v1 resource
 export type Cluster = z.infer<typeof ClusterSchema>
 export type ClustersResponse = z.infer<typeof ClustersResponseSchema>
-// KubernetesCluster matches the v2 endpoint
+export type ClusterIngress = z.infer<typeof ClusterIngressModelV1>
+// "KubernetesCluster" matches the v2 resource
 export type KubernetesCluster = z.infer<typeof KubernetesClusterSchema>
 export type KubernetesClusterResponse = z.infer<typeof KubernetesClusterResponseSchema>
 export type Node = z.infer<typeof NodeSchema>


### PR DESCRIPTION
This pull request adds new v2 ingresses to the cluster. The changes include:

- List ingresses using the new `DataView` component, data is from the /v2/endpoint
- Also added [fakerjs](https://fakerjs.dev/) to help build mocked data