### PR TITLE
Change cards/list view switcher

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-popover": "1.1.11",
     "@radix-ui/react-separator": "1.1.4",
     "@radix-ui/react-slot": "1.2.0",
+    "@radix-ui/react-tabs": "1.1.11",
     "@radix-ui/react-toast": "1.2.13",
     "@radix-ui/react-tooltip": "1.2.4",
     "@ror/js-api-client": "*",

--- a/apps/web/src/app/(protected)/clusters/page.tsx
+++ b/apps/web/src/app/(protected)/clusters/page.tsx
@@ -4,8 +4,8 @@ import { rorApiClient } from '@/services/ror-api'
 import { CodeSnippet } from '@ror/react/components/code-snippet'
 import type { Metadata } from 'next'
 import { ClustersTable } from './cluster-table'
-import { ClusterPageViewSwitch } from './view-switch'
 import { Header } from '@/components/layout/app-shell/header'
+import { TabsViewSwitcher } from '@/components/ui/tabs-view-switcher'
 
 export const metadata: Metadata = {
   title: 'ROR - Clusters',
@@ -86,10 +86,8 @@ export default async function ClustersPage({ searchParams }: ClusterPageProps) {
     <div className='w-full flex flex-col'>
       <Header title='Clusters' />
 
-      <div className='w-full border-b h-28 flex items-center'>
-        <div className='px-12 w-96'>
-          <ClusterPageViewSwitch />
-        </div>
+      <div className='w-full border-b h-28 p-12 flex items-center justify-end'>
+        <TabsViewSwitcher />
       </div>
 
       <section className='px-12 my-8'>

--- a/apps/web/src/components/shadcn/tabs.tsx
+++ b/apps/web/src/components/shadcn/tabs.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react'
+import * as TabsPrimitive from '@radix-ui/react-tabs'
+
+import { cn } from '@/utils/clsxm'
+
+function Tabs({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return <TabsPrimitive.Root data-slot='tabs' className={cn('flex flex-col gap-2', className)} {...props} />
+}
+
+function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot='tabs-list'
+      className={cn(
+        'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot='tabs-trigger'
+      className={cn(
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return <TabsPrimitive.Content data-slot='tabs-content' className={cn('flex-1 outline-none', className)} {...props} />
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/apps/web/src/components/ui/tabs-view-switcher.tsx
+++ b/apps/web/src/components/ui/tabs-view-switcher.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { Tabs, TabsList, TabsTrigger } from '@/components/shadcn/tabs'
+import { LayoutGrid, List } from 'lucide-react'
+import { useRouter, useSearchParams } from 'next/navigation'
+
+export function TabsViewSwitcher() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const selected = searchParams.get('view') ?? 'grid'
+
+  const handleChange = (value: string) => {
+    const url = '/clusters'
+    const params = new URLSearchParams(searchParams)
+
+    // Clean pagination
+    params.delete('page')
+    params.delete('limit')
+
+    if (value === 'grid') {
+      params.delete('view')
+    } else {
+      params.set('view', value)
+    }
+
+    router.push(params.size === 0 ? url : `${url}?${params.toString()}`)
+  }
+
+  return (
+    <Tabs defaultValue={selected} value={selected} onValueChange={handleChange}>
+      <TabsList>
+        <TabsTrigger value='grid'>
+          <LayoutGrid />
+        </TabsTrigger>
+        <TabsTrigger value='list'>
+          <List />
+        </TabsTrigger>
+      </TabsList>
+    </Tabs>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
         "@radix-ui/react-popover": "1.1.11",
         "@radix-ui/react-separator": "1.1.4",
         "@radix-ui/react-slot": "1.2.0",
+        "@radix-ui/react-tabs": "1.1.11",
         "@radix-ui/react-toast": "1.2.13",
         "@radix-ui/react-tooltip": "1.2.4",
         "@ror/js-api-client": "*",
@@ -3999,6 +4000,134 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.0.tgz",
       "integrity": "sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.11.tgz",
+      "integrity": "sha512-4FiKSVoXqPP/KfzlB7lwwqoFV6EPwkrrqGp9cUYXjwDYHhvpnqq79P+EPHKcdoTE7Rl8w/+6s9rTlsfXHES9GA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.2",
+        "@radix-ui/react-roving-focus": "1.1.9",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.6.tgz",
+      "integrity": "sha512-PbhRFK4lIEw9ADonj48tiYWzkllz81TM7KVYyyMMw2cwHO7D5h4XKEblL8NlaRisTK3QTe6tBEhDccFUryxHBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.2",
+        "@radix-ui/react-slot": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.2.tgz",
+      "integrity": "sha512-uHa+l/lKfxuDD2zjN/0peM/RhhSmRjr5YWdk/37EnSv1nJ88uvG85DPexSm8HdFQROd2VdERJ6ynXbkCFi+APw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.9.tgz",
+      "integrity": "sha512-ZzrIFnMYHHCNqSNCsuN6l7wlewBEq0O0BCSBkabJMFXVO51LRUTq71gLP1UxFvmrXElqmPjA5VX7IqC9VpazAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.6",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.2",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
+      "integrity": "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"


### PR DESCRIPTION
This pull request introduces a new tab-based view-switching feature for the Clusters page in the web application. It replaces the previous view-switching component with ShadCN's Tabs. The changes include adding a new dependency, creating reusable tab components, and updating the Clusters page to use the new tab-based view switcher.

![image](https://github.com/user-attachments/assets/3427e008-c8fb-48db-8520-81da8f6ceeaf)
