### PR TITLE
Remove unused tabs on cluster page

### DIFF
--- a/apps/web/src/app/(protected)/clusters/[id]/layout.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/layout.tsx
@@ -15,15 +15,16 @@ interface ClusterPageLayoutProps {
   children: ReactNode
 }
 
+// TODO: Uncomment the following lines when the respective components are available
 const {
   cluster,
-  clusterIngresses,
+  // clusterIngresses,
   clusterNodePools,
-  clusterPolicies,
-  clusterVulnerabilities,
-  clusterCompliance,
-  clusterAbout,
-  clusterRawData,
+  // clusterPolicies,
+  // clusterVulnerabilities,
+  // clusterCompliance,
+  // clusterAbout,
+  // clusterRawData,
 } = routes.app
 
 const createTabNavigationItems = (clusterId: string) => {
@@ -32,34 +33,34 @@ const createTabNavigationItems = (clusterId: string) => {
       label: 'Details',
       href: cluster.getHref(clusterId),
     },
-    {
-      label: clusterIngresses.label,
-      href: clusterIngresses.getHref(clusterId),
-    },
+    // {
+    //   label: clusterIngresses.label,
+    //   href: clusterIngresses.getHref(clusterId),
+    // },
     {
       label: clusterNodePools.label,
       href: clusterNodePools.getHref(clusterId),
     },
-    {
-      label: clusterPolicies.label,
-      href: clusterPolicies.getHref(clusterId),
-    },
-    {
-      label: clusterVulnerabilities.label,
-      href: clusterVulnerabilities.getHref(clusterId),
-    },
-    {
-      label: clusterCompliance.label,
-      href: clusterCompliance.getHref(clusterId),
-    },
-    {
-      label: clusterAbout.label,
-      href: clusterAbout.getHref(clusterId),
-    },
-    {
-      label: clusterRawData.label,
-      href: clusterRawData.getHref(clusterId),
-    },
+    // {
+    //   label: clusterPolicies.label,
+    //   href: clusterPolicies.getHref(clusterId),
+    // },
+    // {
+    //   label: clusterVulnerabilities.label,
+    //   href: clusterVulnerabilities.getHref(clusterId),
+    // },
+    // {
+    //   label: clusterCompliance.label,
+    //   href: clusterCompliance.getHref(clusterId),
+    // },
+    // {
+    //   label: clusterAbout.label,
+    //   href: clusterAbout.getHref(clusterId),
+    // },
+    // {
+    //   label: clusterRawData.label,
+    //   href: clusterRawData.getHref(clusterId),
+    // },
   ]
 }
 


### PR DESCRIPTION
PR comments out pages that will not be used in first release, so they don't appear on cluster page.

![image](https://github.com/user-attachments/assets/2335f04c-bfcb-4fd4-8e7c-45fcd4458d93)
