### PR TITLE
Fix access token bug

### DIFF
--- a/apps/web/__mocks__/browser.ts
+++ b/apps/web/__mocks__/browser.ts
@@ -1,6 +1,7 @@
 import { setupWorker } from 'msw/browser'
+import { handlers } from './handlers'
 
-export const worker = setupWorker()
+export const worker = setupWorker(...handlers)
 
 // @ts-expect-error - hack to prevent hot reload errors
 module.hot?.dispose(() => {

--- a/apps/web/src/app/(public)/sign-in/route.ts
+++ b/apps/web/src/app/(public)/sign-in/route.ts
@@ -6,9 +6,6 @@ import { routes } from '@/config/routes'
  * We do this to reduce the amount of clicks a user might need to do in order to login.
  */
 export async function GET() {
-  /**
-   * Note that "dex" is the id of the provider configured in {@link config/next-auth.ts}
-   */
   await signIn('dex', {
     redirectTo: routes.app.clusters.getHref(),
   })

--- a/apps/web/src/app/api/auth/auth-test/route.ts
+++ b/apps/web/src/app/api/auth/auth-test/route.ts
@@ -1,0 +1,96 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@/config/next-auth'
+import { cookies } from 'next/headers'
+import { jwtDecode } from 'jwt-decode'
+
+/**
+ * This is a comprehensive test endpoint to help verify the authentication flow.
+ * It provides detailed diagnostics about the current authentication state.
+ */
+export async function GET() {
+  try {
+    // Get session through normal auth method
+    const session = await auth()
+
+    // Analyze cookies for debugging
+    const cookieStore = cookies()
+    const allCookies = cookieStore.getAll().map((c) => ({
+      name: c.name,
+      value: c.name.includes('token') ? `${c.value.substring(0, 10)}...` : c.value.substring(0, 5) + '...',
+      path: c.path,
+      expires: c.expires,
+    }))
+
+    // Check for session cookies specifically
+    const sessionCookie =
+      cookieStore.get('next-auth.session-token') || cookieStore.get('__Secure-next-auth.session-token')
+
+    if (!session) {
+      return NextResponse.json({
+        status: 'unauthenticated',
+        message: 'No session found',
+        timestamp: new Date().toISOString(),
+        cookies: {
+          count: allCookies.length,
+          hasSessionCookie: !!sessionCookie,
+          sessionCookieName: sessionCookie?.name,
+          all: allCookies,
+        },
+        environment: {
+          NODE_ENV: process.env.NODE_ENV || 'unknown',
+          NEXTAUTH_URL: process.env.NEXTAUTH_URL || 'not set',
+          hasAuthSecret: !!process.env.NEXTAUTH_SECRET || !!process.env.AUTH_SECRET,
+        },
+      })
+    }
+
+    // Analyze token if available
+    let tokenInfo = {}
+    if (session.accessToken) {
+      try {
+        const decodedToken = jwtDecode(session.accessToken)
+        tokenInfo = {
+          sub: decodedToken.sub,
+          exp: decodedToken.exp,
+          expiresAt: decodedToken.exp ? new Date(decodedToken.exp * 1000).toISOString() : 'unknown',
+          iat: decodedToken.iat,
+          issuedAt: decodedToken.iat ? new Date(decodedToken.iat * 1000).toISOString() : 'unknown',
+        }
+      } catch {
+        tokenInfo = { error: 'Failed to decode token' }
+      }
+    }
+
+    // Return session info without exposing the full token
+    return NextResponse.json({
+      status: 'authenticated',
+      user: session.user,
+      hasAccessToken: !!session.accessToken,
+      // Only return the first few characters of the token for verification
+      tokenPreview: session.accessToken ? `${session.accessToken.substring(0, 10)}...` : 'No token',
+      tokenInfo,
+      cookies: {
+        count: allCookies.length,
+        hasSessionCookie: !!sessionCookie,
+        sessionCookieName: sessionCookie?.name,
+        all: allCookies,
+      },
+      environment: {
+        NODE_ENV: process.env.NODE_ENV || 'unknown',
+        NEXTAUTH_URL: process.env.NEXTAUTH_URL || 'not set',
+        hasAuthSecret: !!process.env.NEXTAUTH_SECRET || !!process.env.AUTH_SECRET,
+      },
+      timestamp: new Date().toISOString(),
+    })
+  } catch (error) {
+    console.error('Auth test error:', error)
+    return NextResponse.json(
+      {
+        status: 'error',
+        message: error instanceof Error ? error.message : 'Unknown error',
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/apps/web/src/app/api/auth/auth-test/route.ts
+++ b/apps/web/src/app/api/auth/auth-test/route.ts
@@ -13,7 +13,7 @@ export async function GET() {
     const session = await auth()
 
     // Analyze cookies for debugging
-    const cookieStore = cookies()
+    const cookieStore = await cookies()
     const allCookies = cookieStore.getAll().map((c) => ({
       name: c.name,
       value: c.name.includes('token') ? `${c.value.substring(0, 10)}...` : c.value.substring(0, 5) + '...',

--- a/apps/web/src/app/api/auth/cookie-debug/route.ts
+++ b/apps/web/src/app/api/auth/cookie-debug/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+
+/**
+ * This is a diagnostic endpoint to check authentication state.
+ * It shows cookie information to help debug auth issues.
+ */
+export async function GET() {
+  try {
+    // Analyze cookies for debugging
+    const cookieStore = cookies()
+    const allCookies = cookieStore.getAll().map((c) => ({
+      name: c.name,
+      value:
+        c.name.includes('token') || c.name.includes('state')
+          ? `${c.value.substring(0, 10)}...`
+          : c.value.substring(0, Math.min(c.value.length, 20)) + (c.value.length > 20 ? '...' : ''),
+      path: c.path,
+      expires: c.expires,
+    }))
+
+    // Check for session cookies specifically
+    const sessionCookie =
+      cookieStore.get('next-auth.session-token') || cookieStore.get('__Secure-next-auth.session-token')
+
+    return NextResponse.json({
+      timestamp: new Date().toISOString(),
+      cookies: {
+        count: allCookies.length,
+        hasSessionCookie: !!sessionCookie,
+        sessionCookieName: sessionCookie?.name,
+        all: allCookies,
+      },
+      environment: {
+        NODE_ENV: process.env.NODE_ENV || 'unknown',
+        NEXTAUTH_URL: process.env.NEXTAUTH_URL || 'not set',
+        hasAuthSecret: !!process.env.NEXTAUTH_SECRET || !!process.env.AUTH_SECRET,
+        AUTH_ISSUER: process.env.AUTH_ISSUER || 'not set',
+      },
+    })
+  } catch (error) {
+    console.error('Cookie diagnostic error:', error)
+    return NextResponse.json(
+      {
+        status: 'error',
+        message: error instanceof Error ? error.message : 'Unknown error',
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/apps/web/src/app/api/auth/debug/route.ts
+++ b/apps/web/src/app/api/auth/debug/route.ts
@@ -12,30 +12,75 @@ interface DecodedToken {
 }
 
 export async function GET(req: NextRequest) {
-  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET || process.env.AUTH_SECRET })
+  // Log all cookies for debugging
+  console.log(
+    '[DEBUG] All cookies:',
+    Object.fromEntries(req.cookies.getAll().map((c) => [c.name, c.value.substring(0, 20) + '...']))
+  )
+
+  // Log request URL
+  console.log('[DEBUG] Request URL:', req.url)
+
+  // Find the right cookie name
+  const sessionCookie =
+    req.cookies.get('next-auth.session-token') || req.cookies.get('__Secure-next-auth.session-token')
+
+  // Try different approaches to get the token
+  console.log('[DEBUG] Trying to get token with cookie name:', sessionCookie?.name)
+
+  const token = await getToken({
+    req,
+    secret: process.env.NEXTAUTH_SECRET || process.env.AUTH_SECRET,
+    secureCookie: process.env.NODE_ENV === 'production',
+    cookieName: sessionCookie?.name,
+  })
 
   if (!token) {
-    console.log('[DEBUG] No token found')
-    return NextResponse.json({ error: 'No token found' }, { status: 401 })
+    console.log('[DEBUG] No token found in request')
+    return NextResponse.json({
+      tokenExists: false,
+      error: 'No token found',
+    })
   }
 
+  console.log('[DEBUG] Token structure:', {
+    keys: Object.keys(token),
+    accessTokenType: typeof token.accessToken,
+    hasExp: 'exp' in token,
+  })
+
   try {
-    const accessToken = token.accessToken as string
-    if (!accessToken) {
-      console.log('[DEBUG] No access token in session')
-      return NextResponse.json({ error: 'No access token in session' }, { status: 401 })
+    let decodedToken: DecodedToken | undefined
+    let expirationTime: number | undefined
+
+    // Handle different token formats
+    if (typeof token.accessToken === 'string') {
+      // Standard case - token has an accessToken that needs decoding
+      console.log('[DEBUG] Found string accessToken in token')
+      decodedToken = jwtDecode<DecodedToken>(token.accessToken)
+      expirationTime = decodedToken.exp * 1000
+    } else if ('exp' in token && typeof token.exp === 'number') {
+      // Token itself contains exp claim
+      console.log('[DEBUG] Using exp from token directly')
+      expirationTime = (token.exp as number) * 1000
+      decodedToken = token as unknown as DecodedToken
+    } else {
+      console.log('[DEBUG] Unusual token format, dumping structure:', token)
+      return NextResponse.json({
+        tokenExists: true,
+        error: 'Unrecognized token format',
+        token,
+      })
     }
 
-    const decodedToken = jwtDecode<DecodedToken>(accessToken)
-    const expirationTime = decodedToken.exp * 1000
     const currentTime = Date.now()
 
     return NextResponse.json({
-      tokenExists: !!token,
-      expirationTime: new Date(expirationTime).toISOString(),
+      tokenExists: true,
+      expirationTime: expirationTime ? new Date(expirationTime).toISOString() : undefined,
       currentTime: new Date(currentTime).toISOString(),
-      isExpired: currentTime >= expirationTime,
-      timeUntilExpiry: expirationTime - currentTime,
+      isExpired: expirationTime ? currentTime >= expirationTime : undefined,
+      timeUntilExpiry: expirationTime ? expirationTime - currentTime : undefined,
       decodedToken,
       token,
     })

--- a/apps/web/src/app/api/auth/environment/route.ts
+++ b/apps/web/src/app/api/auth/environment/route.ts
@@ -4,10 +4,31 @@ import { cookies } from 'next/headers'
 export async function GET() {
   // Use await with cookies() since it returns a Promise
   const cookieStore = await cookies()
-  const sessionCookie = cookieStore.get('next-auth.session-token')
+
+  // Check both possible cookie names based on environment
+  const sessionCookie =
+    cookieStore.get('next-auth.session-token') || cookieStore.get('__Secure-next-auth.session-token')
+
+  // Log all cookies for debugging
+  const allCookies = cookieStore.getAll().map((c) => ({
+    name: c.name,
+    value: (c.value || '').substring(0, 20) + '...',
+  }))
+
+  console.log('[ENV DEBUG] All cookies:', allCookies)
 
   if (!sessionCookie) {
-    return NextResponse.json({ error: 'No session cookie found' }, { status: 401 })
+    return NextResponse.json({
+      tokenExists: false,
+      error: 'No session cookie found',
+      cookies: allCookies,
+      environment: {
+        AUTH_SECRET: process.env.AUTH_SECRET ? '✓ Set' : '✗ Not set',
+        NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET ? '✓ Set' : '✗ Not set',
+        AUTH_ISSUER: process.env.AUTH_ISSUER,
+        NODE_ENV: process.env.NODE_ENV,
+      },
+    })
   }
 
   try {

--- a/apps/web/src/app/auth-debug/page.tsx
+++ b/apps/web/src/app/auth-debug/page.tsx
@@ -1,0 +1,424 @@
+'use client'
+
+import React, { useState, useEffect, useCallback } from 'react'
+import { Button } from '@/components/shadcn/button'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/shadcn/tabs'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/shadcn/card'
+import { Alert, AlertTitle, AlertDescription } from '@/components/shadcn/alert'
+import { Skeleton } from '@/components/shadcn/skeleton'
+import { Info, AlertCircle, CheckCircle, Clock } from 'lucide-react'
+
+// Define interfaces for auth data
+interface DecodedToken {
+  exp?: number
+  iat?: number
+  sub?: string
+  email?: string
+  name?: string
+  [key: string]: string | number | boolean | undefined
+}
+
+interface TokenData {
+  tokenExists: boolean
+  expirationTime?: string
+  currentTime?: string
+  isExpired?: boolean
+  timeUntilExpiry?: number
+  decodedToken?: DecodedToken
+  token?: {
+    accessToken?: string
+    [key: string]: unknown
+  }
+  error?: string
+}
+
+interface EnvironmentData {
+  tokenExists?: boolean
+  cookieName?: string
+  cookieValue?: string
+  environment?: {
+    AUTH_SECRET?: string
+    NEXTAUTH_SECRET?: string
+    AUTH_ISSUER?: string
+    NODE_ENV?: string
+    [key: string]: string | undefined
+  }
+  error?: string
+  details?: string
+}
+
+export default function AuthDebugPage() {
+  const [tokenData, setTokenData] = useState<TokenData | null>(null)
+  const [envData, setEnvData] = useState<EnvironmentData | null>(null)
+  const [loading, setLoading] = useState<{ token: boolean; env: boolean }>({ token: false, env: false })
+  const [error, setError] = useState<string | null>(null)
+  const [autoRefresh, setAutoRefresh] = useState(false)
+
+  const fetchTokenData = useCallback(async () => {
+    setLoading((prev) => ({ ...prev, token: true }))
+    setError(null)
+    try {
+      const response = await fetch('/api/auth/debug')
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        console.error('Token API error response:', response.status, errorData)
+        setTokenData({
+          tokenExists: false,
+          error: `Failed to fetch token data: ${response.status} ${response.statusText}`,
+        })
+        return
+      }
+
+      const data = await response.json()
+      console.log('Token data received:', data)
+      setTokenData(data)
+    } catch (err) {
+      setTokenData({
+        tokenExists: false,
+        error: 'Failed to fetch token data: Network error',
+      })
+      console.error('Error fetching token data:', err)
+    } finally {
+      setLoading((prev) => ({ ...prev, token: false }))
+    }
+  }, [])
+
+  const fetchEnvData = useCallback(async () => {
+    setLoading((prev) => ({ ...prev, env: true }))
+    try {
+      const response = await fetch('/api/auth/environment')
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        console.error('Environment API error response:', response.status, errorData)
+        setEnvData({
+          error: `Failed to fetch environment data: ${response.status} ${response.statusText}`,
+        })
+        return
+      }
+
+      const data = await response.json()
+      console.log('Environment data received:', data)
+
+      if (!data) {
+        console.error('Environment data is null or undefined')
+        setEnvData({
+          error: 'Received empty response from environment API',
+        })
+        return
+      }
+
+      setEnvData(data)
+
+      if (data.error) {
+        setError(`Environment API error: ${data.error}`)
+      }
+    } catch (err) {
+      setEnvData({
+        error: 'Failed to fetch environment data: Network error',
+      })
+      console.error('Error fetching environment data:', err)
+    } finally {
+      setLoading((prev) => ({ ...prev, env: false }))
+    }
+  }, [])
+
+  const refreshData = useCallback(() => {
+    fetchTokenData()
+    fetchEnvData()
+  }, [fetchTokenData, fetchEnvData])
+
+  useEffect(() => {
+    refreshData()
+
+    // Set up auto-refresh if enabled
+    let interval: NodeJS.Timeout | null = null
+    if (autoRefresh) {
+      interval = setInterval(() => {
+        refreshData()
+      }, 10000) // Refresh every 10 seconds
+    }
+
+    return () => {
+      if (interval) {
+        clearInterval(interval)
+      }
+    }
+  }, [autoRefresh, refreshData])
+
+  const formatTime = (ms: number) => {
+    if (ms < 0) return 'Expired'
+
+    const seconds = Math.floor((ms / 1000) % 60)
+    const minutes = Math.floor((ms / (1000 * 60)) % 60)
+    const hours = Math.floor((ms / (1000 * 60 * 60)) % 24)
+
+    return `${hours}h ${minutes}m ${seconds}s`
+  }
+
+  const formatTokenStatus = () => {
+    if (!tokenData) return { color: 'gray', text: 'Unknown', icon: Info }
+    if (tokenData.error) return { color: 'yellow', text: 'Error', icon: AlertCircle }
+    if (!tokenData.tokenExists) return { color: 'red', text: 'Missing', icon: AlertCircle }
+    if (tokenData.isExpired) return { color: 'red', text: 'Expired', icon: AlertCircle }
+
+    return { color: 'green', text: 'Valid', icon: CheckCircle }
+  }
+
+  const tokenStatus = formatTokenStatus()
+
+  return (
+    <div className='container mx-auto p-4'>
+      <div className='flex flex-col gap-4'>
+        <div className='flex justify-between items-center'>
+          <h1 className='text-3xl font-bold'>Auth Debug Dashboard</h1>
+          <div className='flex gap-2 items-center'>
+            <Button
+              variant='outline'
+              size='sm'
+              onClick={() => setAutoRefresh(!autoRefresh)}
+              className={autoRefresh ? 'bg-blue-100 dark:bg-blue-900' : ''}
+            >
+              <Clock className='w-4 h-4 mr-2' />
+              {autoRefresh ? 'Auto-refresh ON' : 'Auto-refresh OFF'}
+            </Button>
+            <Button onClick={refreshData} disabled={loading.token || loading.env}>
+              Refresh All
+            </Button>
+          </div>
+        </div>
+
+        {error && (
+          <Alert variant='destructive' className='my-4'>
+            <AlertCircle className='h-4 w-4' />
+            <AlertTitle>Error</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+          {/* Token Status Card */}
+          <Card>
+            <CardHeader className='pb-2'>
+              <div className='flex justify-between'>
+                <div>
+                  <CardTitle>Token Status</CardTitle>
+                  <CardDescription>Authentication token information</CardDescription>
+                </div>
+                <div
+                  className={`px-3 py-1 rounded-md text-white flex items-center ${
+                    tokenStatus.color === 'green'
+                      ? 'bg-green-500'
+                      : tokenStatus.color === 'red'
+                        ? 'bg-red-500'
+                        : tokenStatus.color === 'yellow'
+                          ? 'bg-yellow-500'
+                          : 'bg-gray-500'
+                  }`}
+                >
+                  {React.createElement(tokenStatus.icon, { className: 'w-4 h-4 mr-1' })}
+                  {tokenStatus.text}
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Button onClick={fetchTokenData} disabled={loading.token} className='mb-4' variant='outline' size='sm'>
+                Refresh Token Data
+              </Button>
+
+              {loading.token ? (
+                <div className='space-y-2'>
+                  <Skeleton className='h-4 w-full' />
+                  <Skeleton className='h-4 w-full' />
+                  <Skeleton className='h-4 w-full' />
+                </div>
+              ) : tokenData?.error ? (
+                <Alert variant='destructive'>
+                  <AlertCircle className='h-4 w-4' />
+                  <AlertTitle>Token Error</AlertTitle>
+                  <AlertDescription>{tokenData.error}</AlertDescription>
+                </Alert>
+              ) : tokenData?.tokenExists === false ? (
+                <Alert>
+                  <Info className='h-4 w-4' />
+                  <AlertTitle>No Token</AlertTitle>
+                  <AlertDescription>No authentication token was found. Try logging in first.</AlertDescription>
+                </Alert>
+              ) : tokenData ? (
+                <Tabs defaultValue='details'>
+                  <TabsList className='mb-2'>
+                    <TabsTrigger value='details'>Details</TabsTrigger>
+                    <TabsTrigger value='raw'>Raw Data</TabsTrigger>
+                  </TabsList>
+                  <TabsContent value='details' className='space-y-2'>
+                    <div className='bg-gray-100 dark:bg-gray-800 p-3 rounded-md space-y-1'>
+                      <p className='grid grid-cols-2'>
+                        <span className='font-medium'>Status:</span>
+                        <span className={tokenData.isExpired ? 'text-red-500' : 'text-green-500'}>
+                          {tokenData.isExpired ? 'Expired' : 'Valid'}
+                        </span>
+                      </p>
+                      <p className='grid grid-cols-2'>
+                        <span className='font-medium'>Current Time:</span>
+                        <span>{tokenData.currentTime}</span>
+                      </p>
+                      <p className='grid grid-cols-2'>
+                        <span className='font-medium'>Expiration:</span>
+                        <span>{tokenData.expirationTime}</span>
+                      </p>
+                      <p className='grid grid-cols-2'>
+                        <span className='font-medium'>Time Until Expiry:</span>
+                        <span>
+                          {tokenData.timeUntilExpiry !== undefined ? formatTime(tokenData.timeUntilExpiry) : 'N/A'}
+                        </span>
+                      </p>
+                      {tokenData.decodedToken?.sub && (
+                        <p className='grid grid-cols-2'>
+                          <span className='font-medium'>Subject:</span>
+                          <span>{tokenData.decodedToken.sub}</span>
+                        </p>
+                      )}
+                      {tokenData.decodedToken?.email && (
+                        <p className='grid grid-cols-2'>
+                          <span className='font-medium'>Email:</span>
+                          <span>{tokenData.decodedToken.email}</span>
+                        </p>
+                      )}
+                    </div>
+                  </TabsContent>
+                  <TabsContent value='raw'>
+                    <div className='text-xs overflow-auto bg-gray-100 dark:bg-gray-800 p-3 rounded-md'>
+                      <pre>{JSON.stringify(tokenData, null, 2)}</pre>
+                    </div>
+                  </TabsContent>
+                </Tabs>
+              ) : null}
+            </CardContent>
+          </Card>
+
+          {/* Environment Card */}
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardTitle>Environment Information</CardTitle>
+              <CardDescription>Authentication configuration</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button onClick={fetchEnvData} disabled={loading.env} className='mb-4' variant='outline' size='sm'>
+                Refresh Environment Data
+              </Button>
+
+              {loading.env ? (
+                <div className='space-y-2'>
+                  <Skeleton className='h-4 w-full' />
+                  <Skeleton className='h-4 w-full' />
+                  <Skeleton className='h-4 w-full' />
+                </div>
+              ) : envData?.error ? (
+                <Alert variant='destructive'>
+                  <AlertCircle className='h-4 w-4' />
+                  <AlertTitle>Environment Error</AlertTitle>
+                  <AlertDescription>{envData.error}</AlertDescription>
+                </Alert>
+              ) : envData ? (
+                <Tabs defaultValue='env'>
+                  <TabsList className='mb-2'>
+                    <TabsTrigger value='env'>Environment</TabsTrigger>
+                    <TabsTrigger value='cookie'>Session Cookie</TabsTrigger>
+                    <TabsTrigger value='raw'>Raw Data</TabsTrigger>
+                  </TabsList>
+                  <TabsContent value='env' className='space-y-2'>
+                    <div className='bg-gray-100 dark:bg-gray-800 p-3 rounded-md space-y-1'>
+                      {envData.environment ? (
+                        <>
+                          <p className='grid grid-cols-2'>
+                            <span className='font-medium'>Node Environment:</span>
+                            <span>{envData.environment.NODE_ENV || 'Not set'}</span>
+                          </p>
+                          <p className='grid grid-cols-2'>
+                            <span className='font-medium'>AUTH_SECRET:</span>
+                            <span>{envData.environment.AUTH_SECRET || 'Not set'}</span>
+                          </p>
+                          <p className='grid grid-cols-2'>
+                            <span className='font-medium'>NEXTAUTH_SECRET:</span>
+                            <span>{envData.environment.NEXTAUTH_SECRET || 'Not set'}</span>
+                          </p>
+                          <p className='grid grid-cols-2'>
+                            <span className='font-medium'>AUTH_ISSUER:</span>
+                            <span>{envData.environment.AUTH_ISSUER || 'Not set'}</span>
+                          </p>
+                        </>
+                      ) : (
+                        <p className='text-yellow-600 dark:text-yellow-400'>Environment data not available</p>
+                      )}
+                    </div>
+                  </TabsContent>
+                  <TabsContent value='cookie'>
+                    <div className='bg-gray-100 dark:bg-gray-800 p-3 rounded-md'>
+                      {envData.cookieName ? (
+                        <div className='space-y-1'>
+                          <p className='grid grid-cols-2'>
+                            <span className='font-medium'>Cookie Name:</span>
+                            <span>{envData.cookieName}</span>
+                          </p>
+                          <p className='grid grid-cols-2'>
+                            <span className='font-medium'>Cookie Value:</span>
+                            <span className='truncate'>{envData.cookieValue?.substring(0, 20)}...</span>
+                          </p>
+                        </div>
+                      ) : (
+                        <p className='text-red-500'>No session cookie found</p>
+                      )}
+                    </div>
+                  </TabsContent>
+                  <TabsContent value='raw'>
+                    <div className='text-xs overflow-auto bg-gray-100 dark:bg-gray-800 p-3 rounded-md'>
+                      <pre>{JSON.stringify(envData, null, 2)}</pre>
+                    </div>
+                  </TabsContent>
+                </Tabs>
+              ) : null}
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Troubleshooting Guide */}
+        <Card className='mt-4'>
+          <CardHeader>
+            <CardTitle>Troubleshooting Guide</CardTitle>
+            <CardDescription>Common authentication issues and solutions</CardDescription>
+          </CardHeader>
+          <CardContent className='space-y-4'>
+            <div>
+              <h3 className='font-semibold'>Missing Token</h3>
+              <p className='text-sm text-gray-600 dark:text-gray-400'>
+                If no token is found, try logging out and logging back in. Check that cookies are enabled in your
+                browser.
+              </p>
+            </div>
+            <div>
+              <h3 className='font-semibold'>Token Expired</h3>
+              <p className='text-sm text-gray-600 dark:text-gray-400'>
+                If token is expired, log out and log back in to refresh your session.
+              </p>
+            </div>
+            <div>
+              <h3 className='font-semibold'>Different Behavior in Production</h3>
+              <p className='text-sm text-gray-600 dark:text-gray-400'>
+                Production environments use secure cookies which require HTTPS. Make sure all environment variables
+                (NEXTAUTH_SECRET, AUTH_SECRET) are properly set in both environments.
+              </p>
+            </div>
+            <div>
+              <h3 className='font-semibold'>Missing Environment Variables</h3>
+              <p className='text-sm text-gray-600 dark:text-gray-400'>
+                Check that all required environment variables are set. In production, environment variables might be set
+                differently than in development.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/mock-provider.tsx
+++ b/apps/web/src/app/mock-provider.tsx
@@ -14,13 +14,50 @@ import { onUnhandledRequest } from '@/__mocks__/utils/on-unhandled-request'
 const mockingEnabledPromise =
   typeof window !== 'undefined' && process.env.NEXT_PUBLIC_MOCKING_ENABLED === 'true'
     ? import('@/__mocks__/browser').then(async ({ worker }) => {
-        await worker.start({
-          onUnhandledRequest: onUnhandledRequest,
-        })
+        try {
+          console.log('[MSW] Starting service worker...')
 
-        worker.use(...handlers)
+          // Check if service worker is already registered
+          const registrations = await navigator.serviceWorker.getRegistrations()
+          const hasMockWorker = registrations.some(
+            (reg) => reg.active && reg.active.scriptURL.includes('mockServiceWorker.js')
+          )
 
-        console.log(worker.listHandlers())
+          if (hasMockWorker) {
+            console.log('[MSW] Mock service worker already registered, unregistering first')
+            await Promise.all(
+              registrations
+                .filter((reg) => reg.active && reg.active.scriptURL.includes('mockServiceWorker.js'))
+                .map((reg) => reg.unregister())
+            )
+          }
+
+          // Start with a fresh worker
+          await worker
+            .start({
+              onUnhandledRequest: onUnhandledRequest,
+              serviceWorker: {
+                url: '/mockServiceWorker.js',
+                options: {
+                  scope: '/',
+                },
+              },
+            })
+            .catch((e) => {
+              console.error('[MSW] Failed to start worker:', e)
+              // Return a friendlier error for users
+              throw new Error(
+                'MSW initialization failed. Try disabling NEXT_PUBLIC_MOCKING_ENABLED or refreshing the page.'
+              )
+            })
+
+          worker.use(...handlers)
+
+          console.log('[MSW] Service worker started successfully!')
+          console.log('[MSW] Registered handlers:', worker.listHandlers().length)
+        } catch (error) {
+          console.error('[MSW] Service worker registration failed:', error)
+        }
       })
     : Promise.resolve()
 

--- a/apps/web/src/app/sign-in-debug/page.tsx
+++ b/apps/web/src/app/sign-in-debug/page.tsx
@@ -11,7 +11,17 @@ import { Info, AlertCircle } from 'lucide-react'
 export default function SignInDebugPage() {
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
-  const [env, setEnv] = useState<any>(null)
+  interface EnvData {
+    environment?: {
+      NODE_ENV?: string
+      AUTH_SECRET?: string
+      NEXTAUTH_SECRET?: string
+      AUTH_ISSUER?: string
+    }
+    cookieName?: string
+    cookieValue?: string
+  }
+  const [env, setEnv] = useState<EnvData | null>(null)
 
   useEffect(() => {
     // Fetch environment information
@@ -42,9 +52,14 @@ export default function SignInDebugPage() {
       })
 
       console.log('Sign-in result:', result)
-    } catch (err: any) {
-      setError(err.message || 'An unknown error occurred')
-      console.error('Sign-in error:', err)
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message)
+        console.error('Sign-in error:', err)
+      } else {
+        setError('An unknown error occurred')
+        console.error('Sign-in error:', err)
+      }
     } finally {
       setLoading(false)
     }

--- a/apps/web/src/app/sign-in-debug/page.tsx
+++ b/apps/web/src/app/sign-in-debug/page.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { signIn } from 'next-auth/react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/shadcn/card'
+import { Button } from '@/components/shadcn/button'
+import { Alert, AlertDescription, AlertTitle } from '@/components/shadcn/alert'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/shadcn/tabs'
+import { Info, AlertCircle } from 'lucide-react'
+
+export default function SignInDebugPage() {
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [env, setEnv] = useState<any>(null)
+
+  useEffect(() => {
+    // Fetch environment information
+    fetch('/api/auth/environment')
+      .then((res) => res.json())
+      .then((data) => setEnv(data))
+      .catch((err) => setError('Failed to load environment data: ' + err.message))
+  }, [])
+
+  const handleSignIn = async () => {
+    try {
+      setLoading(true)
+      setError(null)
+
+      console.log('Starting sign-in process...')
+
+      // Log environment before sign-in
+      console.log('Environment before sign-in:', {
+        callbackUrl: window.location.origin + '/auth-debug',
+        currentUrl: window.location.href,
+        origin: window.location.origin,
+      })
+
+      // Attempt sign-in
+      const result = await signIn('dex', {
+        callbackUrl: window.location.origin + '/auth-debug',
+        redirect: true,
+      })
+
+      console.log('Sign-in result:', result)
+    } catch (err: any) {
+      setError(err.message || 'An unknown error occurred')
+      console.error('Sign-in error:', err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className='container mx-auto p-4'>
+      <h1 className='text-3xl font-bold mb-4'>Sign In Debug</h1>
+
+      {error && (
+        <Alert variant='destructive' className='mb-4'>
+          <AlertCircle className='h-4 w-4' />
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className='grid gap-4 md:grid-cols-2'>
+        <Card>
+          <CardHeader>
+            <CardTitle>Authentication Test</CardTitle>
+            <CardDescription>Try signing in with different options</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className='space-y-4'>
+              <Button onClick={handleSignIn} disabled={loading} className='w-full'>
+                {loading ? 'Signing in...' : 'Sign in with Dex'}
+              </Button>
+
+              <Alert>
+                <Info className='h-4 w-4' />
+                <AlertTitle>Debug Mode</AlertTitle>
+                <AlertDescription>
+                  This will redirect you to the Dex identity provider and back to the auth-debug page.
+                </AlertDescription>
+              </Alert>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Environment</CardTitle>
+            <CardDescription>Authentication configuration details</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {env ? (
+              <Tabs defaultValue='env'>
+                <TabsList className='mb-2'>
+                  <TabsTrigger value='env'>Environment</TabsTrigger>
+                  <TabsTrigger value='cookies'>Cookies</TabsTrigger>
+                </TabsList>
+                <TabsContent value='env'>
+                  <div className='text-sm bg-gray-100 dark:bg-gray-800 p-3 rounded-md'>
+                    <p>
+                      NODE_ENV: <span className='font-mono'>{env.environment?.NODE_ENV || 'Not set'}</span>
+                    </p>
+                    <p>AUTH_SECRET: {env.environment?.AUTH_SECRET || 'Not set'}</p>
+                    <p>NEXTAUTH_SECRET: {env.environment?.NEXTAUTH_SECRET || 'Not set'}</p>
+                    <p>
+                      AUTH_ISSUER: <span className='font-mono'>{env.environment?.AUTH_ISSUER || 'Not set'}</span>
+                    </p>
+                  </div>
+                </TabsContent>
+                <TabsContent value='cookies'>
+                  <div className='text-sm bg-gray-100 dark:bg-gray-800 p-3 rounded-md'>
+                    {env.cookieName ? (
+                      <>
+                        <p>
+                          Cookie found: <span className='font-mono'>{env.cookieName}</span>
+                        </p>
+                        <p>
+                          Value: <span className='font-mono truncate'>{env.cookieValue?.substring(0, 20)}...</span>
+                        </p>
+                      </>
+                    ) : (
+                      <p>No session cookie found</p>
+                    )}
+                  </div>
+                </TabsContent>
+              </Tabs>
+            ) : (
+              <div className='text-sm'>Loading environment data...</div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/config/next-auth.ts
+++ b/apps/web/src/config/next-auth.ts
@@ -28,7 +28,22 @@ const dexIdpProvider: Provider = {
   authorization: {
     params: {
       scope: 'openid profile email groups',
+      response_type: 'code',
     },
+  },
+  checks: ['pkce', 'state'],
+  client: {
+    token_endpoint_auth_method: 'client_secret_basic',
+  },
+  profile(profile) {
+    console.log('[NEXTAUTH] Profile received from Dex:', profile)
+    return {
+      id: profile.sub,
+      name: profile.name || profile.preferred_username || profile.sub,
+      email: profile.email,
+      image: profile.picture,
+      emailVerified: null,
+    }
   },
 }
 
@@ -42,24 +57,141 @@ const trusthost = Boolean(JSON.parse(env.AUTH_TRUST_HOST))
  * - signOut function
  * - auth utility function
  */
+// Log the environment configuration for debugging
+console.log('[NEXTAUTH] Configuration:', {
+  environment: process.env.NODE_ENV,
+  trustHost: trusthost,
+  issuerSet: !!env.AUTH_ISSUER,
+  nextAuthUrl: process.env.NEXTAUTH_URL || 'Not set',
+  secretsAvailable: {
+    NEXTAUTH_SECRET: !!process.env.NEXTAUTH_SECRET,
+    AUTH_SECRET: !!process.env.AUTH_SECRET,
+  },
+})
+
 export const { handlers, signIn, signOut, auth } = NextAuth({
   providers: [dexIdpProvider],
   trustHost: trusthost,
+  debug: true, // Enable debug logs in all environments for troubleshooting
+
+  // Force JWT strategy for tokens
+  session: {
+    strategy: 'jwt',
+    maxAge: 30 * 24 * 60 * 60, // 30 days
+  },
+
+  // Enhanced cookie configuration to be consistent across environments
+  cookies: {
+    sessionToken: {
+      name: process.env.NODE_ENV === 'production' ? '__Secure-next-auth.session-token' : 'next-auth.session-token',
+      options: {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        secure: process.env.NODE_ENV === 'production',
+        maxAge: 30 * 24 * 60 * 60, // 30 days
+      },
+    },
+    // Add explicit configuration for other cookies to ensure consistency
+    callbackUrl: {
+      name: process.env.NODE_ENV === 'production' ? '__Secure-next-auth.callback-url' : 'next-auth.callback-url',
+      options: {
+        sameSite: 'lax',
+        path: '/',
+        secure: process.env.NODE_ENV === 'production',
+      },
+    },
+    csrfToken: {
+      name: process.env.NODE_ENV === 'production' ? '__Host-next-auth.csrf-token' : 'next-auth.csrf-token',
+      options: {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        secure: process.env.NODE_ENV === 'production',
+      },
+    },
+  },
   pages: {
     signIn: routes.auth.signIn.getHref(),
+    error: '/auth-debug', // Redirect to our debug page on auth errors
   },
   callbacks: {
     jwt({ token, account }) {
+      // Only log during initial token creation or refresh
+      if (account) {
+        console.log('[NEXTAUTH] JWT callback with account:', {
+          provider: account.provider,
+          hasAccessToken: !!account.access_token,
+          tokenType: typeof account.access_token,
+          expires_in: account.expires_in,
+        })
+      }
+
       if (account?.provider === 'dex') {
         if (!account?.access_token) {
+          console.error('[NEXTAUTH] Missing access_token in account data')
           throw new Error('Did not receive access_token from DexIdp on login callback')
         }
-        return { ...token, accessToken: account.access_token }
+
+        try {
+          // Decode the token to verify it's valid and extract expiration
+          const decodedAccessToken = jwtDecode(account.access_token)
+          console.log('[NEXTAUTH] Decoded access token:', {
+            hasExp: 'exp' in decodedAccessToken,
+            expValue: decodedAccessToken.exp,
+            expDate: decodedAccessToken.exp ? new Date(decodedAccessToken.exp * 1000).toISOString() : 'N/A',
+            sub: decodedAccessToken.sub || 'N/A',
+          })
+
+          // Store both the access token and its expiration
+          const updatedToken = {
+            ...token,
+            accessToken: account.access_token,
+            // Add exp explicitly for easier access in middleware
+            exp: decodedAccessToken.exp,
+            sub: decodedAccessToken.sub,
+            tokenType: 'Bearer',
+          }
+
+          console.log('[NEXTAUTH] Successfully added accessToken to JWT')
+          return updatedToken
+        } catch (error) {
+          console.error('[NEXTAUTH] Error decoding access token:', error)
+          // Still return the token with the access token but without decoded properties
+          return { ...token, accessToken: account.access_token }
+        }
       }
       return token
     },
     session({ session, token }) {
+      // Debug log the token contents (without exposing sensitive data)
+      console.log('[NEXTAUTH] Session callback:', {
+        hasAccessToken: !!token.accessToken,
+        tokenType: typeof token.accessToken,
+        hasExpField: 'exp' in token,
+        expValue: token.exp,
+        expiresAt: token.exp ? new Date(Number(token.exp) * 1000).toISOString() : 'N/A',
+      })
+
+      if (!token.accessToken) {
+        console.warn('[NEXTAUTH] Missing accessToken in token during session creation')
+      }
+
+      // Transfer necessary properties to the session
       session.accessToken = token.accessToken as string
+
+      // Add user information if available
+      if (token.sub && !session.user) {
+        session.user = {
+          id: token.sub as string,
+          name: (token.name as string) || (token.sub as string),
+          email: token.email as string,
+          // Add required properties for type compatibility
+          emailVerified: null,
+          image: null,
+        }
+      }
+
       return session
     },
     authorized: async ({ request, auth }) => {
@@ -76,14 +208,54 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
 function validateAuthToken(session: Session | null): boolean {
   if (!session) {
+    console.log('[NEXTAUTH] validateAuthToken: No session available')
+    return false
+  }
+
+  if (!session.accessToken) {
+    console.log('[NEXTAUTH] validateAuthToken: No accessToken in session')
     return false
   }
 
   try {
-    const decodedToken = jwtDecode(session.accessToken)
-    const expirationTime = (decodedToken.exp as number) * 1000
-    return expirationTime >= Date.now()
-  } catch {
+    // Check if the token is a JWT that needs decoding
+    let expirationTime: number
+
+    // If the session object itself has the exp property (added in our JWT callback)
+    interface SessionWithExp extends Session {
+      exp?: number
+    }
+
+    if (session.user && 'exp' in session && typeof (session as SessionWithExp).exp === 'number') {
+      expirationTime = (session as SessionWithExp).exp! * 1000
+      console.log('[NEXTAUTH] Using exp from session object')
+    } else {
+      // Otherwise decode the accessToken
+      const decodedToken = jwtDecode(session.accessToken)
+
+      if (typeof decodedToken.exp !== 'number') {
+        console.warn('[NEXTAUTH] validateAuthToken: Token missing expiration time')
+        return false
+      }
+
+      expirationTime = decodedToken.exp * 1000
+    }
+
+    const currentTime = Date.now()
+    const isValid = expirationTime >= currentTime
+    const timeRemaining = Math.max(0, expirationTime - currentTime)
+
+    console.log('[NEXTAUTH] Token validation:', {
+      valid: isValid,
+      expiresAt: new Date(expirationTime).toISOString(),
+      now: new Date(currentTime).toISOString(),
+      timeRemaining: `${Math.floor(timeRemaining / 1000)}s`,
+      timeRemainingMinutes: `${Math.floor(timeRemaining / (1000 * 60))}m`,
+    })
+
+    return isValid
+  } catch (error) {
+    console.error('[NEXTAUTH] Error validating token:', error)
     return false
   }
 }

--- a/apps/web/src/config/next-auth.ts
+++ b/apps/web/src/config/next-auth.ts
@@ -72,7 +72,7 @@ console.log('[NEXTAUTH] Configuration:', {
 export const { handlers, signIn, signOut, auth } = NextAuth({
   providers: [dexIdpProvider],
   trustHost: trusthost,
-  debug: true, // Enable debug logs in all environments for troubleshooting
+  debug: process.env.NODE_ENV !== 'production', // Enable debug logs only in non-production environments
 
   // Force JWT strategy for tokens
   session: {

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -15,12 +15,7 @@ interface DecodedToken {
 const isDev = process.env.NODE_ENV !== 'production'
 
 // Debug route patterns that should bypass authentication
-const debugRoutes = [
-  '/sign-in',
-  '/sign-in-debug',
-  '/auth-debug',
-  '/api/auth', // This covers all auth routes including callbacks
-]
+const debugRoutes = ['/sign-in', '/sign-in-debug', '/auth-debug', '/api/auth']
 
 export async function middleware(req: NextRequest) {
   const path = req.nextUrl.pathname
@@ -85,7 +80,6 @@ export async function middleware(req: NextRequest) {
   console.log(`[MIDDLEWARE] Token exists with properties:`, Object.keys(token))
 
   try {
-    // Check for possible token formats - production vs development may differ
     console.log(`[MIDDLEWARE] Token format validation:`, {
       hasAccessToken: 'accessToken' in token,
       accessTokenType: typeof token.accessToken,
@@ -95,22 +89,17 @@ export async function middleware(req: NextRequest) {
     let expirationTime: number
     let tokenToValidate: string | null = null
 
-    // Handle different token structures we might encounter
     if (typeof token.accessToken === 'string') {
-      // Standard case: token has an accessToken string that needs decoding
       tokenToValidate = token.accessToken
       console.log(`[MIDDLEWARE] Using accessToken string from token`)
     } else if ('exp' in token && typeof token.exp === 'number') {
-      // Alternative case: token itself is already decoded and has exp
       expirationTime = (token.exp as number) * 1000
       console.log(`[MIDDLEWARE] Using token's own exp field: ${token.exp}`)
     } else {
-      // Unknown format
       console.log(`[MIDDLEWARE] Invalid token format - neither accessToken string nor exp field found`)
       return NextResponse.redirect(`${req.nextUrl.origin}/sign-in`)
     }
 
-    // If we have a token string, decode it to check expiration
     if (tokenToValidate) {
       const decodedToken = jwtDecode<DecodedToken>(tokenToValidate)
 
@@ -123,7 +112,6 @@ export async function middleware(req: NextRequest) {
       console.log(`[MIDDLEWARE] Decoded token exp: ${decodedToken.exp}`)
     }
 
-    // Check expiration
     const currentTime = Date.now()
     console.log(`[MIDDLEWARE] Token expiration:`, {
       currentTime: new Date(currentTime).toISOString(),

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -11,34 +11,128 @@ interface DecodedToken {
   [key: string]: string | number | boolean | undefined
 }
 
-export async function middleware(req: NextRequest) {
-  console.log(`[MIDDLEWARE] Running for path: ${req.nextUrl.pathname}`)
+// For debugging use
+const isDev = process.env.NODE_ENV !== 'production'
 
-  // Get token from request
-  const token = await getToken({
+// Debug route patterns that should bypass authentication
+const debugRoutes = [
+  '/sign-in',
+  '/sign-in-debug',
+  '/auth-debug',
+  '/api/auth', // This covers all auth routes including callbacks
+]
+
+export async function middleware(req: NextRequest) {
+  const path = req.nextUrl.pathname
+
+  // Log middleware execution context
+  console.log(`[MIDDLEWARE] Running for path: ${path}`)
+  console.log(`[MIDDLEWARE] Environment: ${process.env.NODE_ENV}`)
+
+  // Skip auth for debug routes
+  if (debugRoutes.some((route) => path.startsWith(route))) {
+    console.log(`[MIDDLEWARE] Bypassing auth for debug route: ${path}`)
+    return NextResponse.next()
+  }
+
+  // Check if cookies exist before trying to get token
+  const sessionCookie =
+    req.cookies.get('next-auth.session-token') || req.cookies.get('__Secure-next-auth.session-token')
+
+  console.log(`[MIDDLEWARE] Cookie check:`, {
+    hasCookie: !!sessionCookie,
+    cookieName: sessionCookie?.name,
+    isSecure: sessionCookie?.name?.startsWith('__Secure'),
+  })
+
+  // Environment-specific configuration
+  const getTokenOptions = {
     req,
     secret: process.env.NEXTAUTH_SECRET || process.env.AUTH_SECRET,
+    secureCookie: process.env.NODE_ENV === 'production',
+  }
+
+  console.log(`[MIDDLEWARE] Getting token with options:`, {
+    hasSecret: !!(process.env.NEXTAUTH_SECRET || process.env.AUTH_SECRET),
+    secureCookie: getTokenOptions.secureCookie,
   })
+
+  // Enhanced debugging in dev mode
+  if (isDev) {
+    console.log(`[MIDDLEWARE] Raw cookies:`, {
+      all: Object.fromEntries(req.cookies.getAll().map((c) => [c.name, c.value])),
+    })
+  }
+
+  // Try to get token from request with explicit cookie handling
+  const tokenOptions = {
+    ...getTokenOptions,
+    cookieName: sessionCookie?.name, // Use the exact cookie name we found
+  }
+
+  console.log(`[MIDDLEWARE] Getting token with updated options:`, {
+    ...tokenOptions,
+    cookieName: tokenOptions.cookieName,
+  })
+
+  const token = await getToken(tokenOptions)
 
   if (!token) {
     console.log(`[MIDDLEWARE] No token found, redirecting to sign-in`)
     return NextResponse.redirect(`${req.nextUrl.origin}/sign-in`)
   }
 
-  console.log(`[MIDDLEWARE] Token exists`)
+  console.log(`[MIDDLEWARE] Token exists with properties:`, Object.keys(token))
 
   try {
-    if (typeof token.accessToken !== 'string') {
-      console.log(`[MIDDLEWARE] Invalid access token format`)
+    // Check for possible token formats - production vs development may differ
+    console.log(`[MIDDLEWARE] Token format validation:`, {
+      hasAccessToken: 'accessToken' in token,
+      accessTokenType: typeof token.accessToken,
+      hasExpField: 'exp' in token,
+    })
+
+    let expirationTime: number
+    let tokenToValidate: string | null = null
+
+    // Handle different token structures we might encounter
+    if (typeof token.accessToken === 'string') {
+      // Standard case: token has an accessToken string that needs decoding
+      tokenToValidate = token.accessToken
+      console.log(`[MIDDLEWARE] Using accessToken string from token`)
+    } else if ('exp' in token && typeof token.exp === 'number') {
+      // Alternative case: token itself is already decoded and has exp
+      expirationTime = (token.exp as number) * 1000
+      console.log(`[MIDDLEWARE] Using token's own exp field: ${token.exp}`)
+    } else {
+      // Unknown format
+      console.log(`[MIDDLEWARE] Invalid token format - neither accessToken string nor exp field found`)
       return NextResponse.redirect(`${req.nextUrl.origin}/sign-in`)
     }
 
-    // Decode token and check expiration
-    const decodedToken = jwtDecode<DecodedToken>(token.accessToken)
-    const expirationTime = decodedToken.exp * 1000
-    const currentTime = Date.now()
+    // If we have a token string, decode it to check expiration
+    if (tokenToValidate) {
+      const decodedToken = jwtDecode<DecodedToken>(tokenToValidate)
 
-    if (currentTime >= expirationTime) {
+      if (!decodedToken.exp) {
+        console.log(`[MIDDLEWARE] Token missing exp claim`)
+        return NextResponse.redirect(`${req.nextUrl.origin}/sign-in`)
+      }
+
+      expirationTime = decodedToken.exp * 1000
+      console.log(`[MIDDLEWARE] Decoded token exp: ${decodedToken.exp}`)
+    }
+
+    // Check expiration
+    const currentTime = Date.now()
+    console.log(`[MIDDLEWARE] Token expiration:`, {
+      currentTime: new Date(currentTime).toISOString(),
+      expirationTime: new Date(expirationTime!).toISOString(),
+      isExpired: currentTime >= expirationTime!,
+      timeRemaining: `${Math.floor((expirationTime! - currentTime) / 1000)}s`,
+    })
+
+    if (currentTime >= expirationTime!) {
       console.log(`[MIDDLEWARE] Token expired, redirecting to sign-in`)
       return NextResponse.redirect(`${req.nextUrl.origin}/sign-in`)
     }
@@ -60,7 +154,10 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon.ico, sitemap.xml, robots.txt (metadata files)
      * - sign-in (authentication page)
+     * - sign-in-debug (authentication debug page)
+     * - auth-debug (debugging page)
+     * - api/auth (authentication API routes)
      */
-    `/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|sign-in).*)`,
+    `/((?!api|_next/static|_next/image|_next/webpack|favicon.ico|sitemap.xml|robots.txt|sign-in|sign-in-debug|auth-debug|mockServiceWorker).*)`,
   ],
 }

--- a/scripts/run-with-debug.sh
+++ b/scripts/run-with-debug.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Script to run the Next.js dev server with enhanced debug settings
+
+# Set environment variables for debugging
+export NODE_OPTIONS="--inspect"
+export NEXT_PUBLIC_MOCKING_ENABLED="false" # Disable MSW to avoid service worker issues
+export NEXT_DEBUG="1"
+export DEBUG="next-auth:*" # Enable NextAuth debug logs
+
+echo "Starting Next.js with debug options..."
+echo "* NextAuth debugging enabled"
+echo "* Node Inspector enabled"
+echo "* MSW mocking disabled"
+echo "--------------------------------------------"
+
+# Change to the web app directory and run dev server
+cd $(dirname "$0")/../apps/web
+npm run dev -- --turbopack


### PR DESCRIPTION
This pull request includes significant updates to the authentication system, debugging tools, and mocking service worker setup. Key changes focus on enhancing diagnostics for authentication flows, improving cookie handling, and adding debugging features for developers. Additionally, updates to the Dex identity provider configuration and service worker management provide better reliability and usability.

### Enhancements to Authentication and Debugging:

1. **New Diagnostic Endpoints for Authentication:**
   - Added `auth-test` and `cookie-debug` endpoints to provide detailed diagnostics about authentication state, session cookies, and environment variables. These endpoints help debug issues with tokens and cookies. (`apps/web/src/app/api/auth/auth-test/route.ts` and `apps/web/src/app/api/auth/cookie-debug/route.ts`)

2. **Improved Debugging in Authentication Flow:**
   - Enhanced logging in the `auth/debug` endpoint to include cookie details, token structure, and environment data, ensuring easier troubleshooting of token-related issues. (`apps/web/src/app/api/auth/debug/route.ts`)

3. **Debugging Page for Sign-In:**
   - Introduced a new `sign-in-debug` page with interactive tools to test sign-in flows and display environment and cookie details for debugging purposes. (`apps/web/src/app/sign-in-debug/page.tsx`)

### Updates to Dex Identity Provider Configuration:

4. **Enhanced Dex Provider Settings:**
   - Updated Dex provider configuration to include PKCE checks, client authentication methods, and improved profile handling. Added debug logs for better visibility into the authentication process. (`apps/web/src/config/next-auth.ts`)

### Improvements to Mocking Service Worker:

5. **Service Worker Management Enhancements:**
   - Improved the mocking service worker setup to ensure proper registration and cleanup of previous instances, reducing potential conflicts during development. Added detailed error handling and logs for debugging. (`apps/web/src/app/mock-provider.tsx`)