### PR TITLE
Implement node pools display

### DIFF
--- a/apps/web/src/app/(protected)/clusters/[id]/node-pools/page-view.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/node-pools/page-view.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { convertBytes } from '@/utils/bytes'
-import { ColumnDef } from '@tanstack/react-table'
-// import {TableCell, TableRow } from "@/components/shadcn/table"
+import { ColumnDef, SortingState } from '@tanstack/react-table'
 import React, { useState } from 'react'
 import { DataTable } from '@/components/ui/data-table'
 import { Button } from '@/components/shadcn/button'
@@ -58,6 +57,10 @@ interface DataTableProps<TData> {
 export function PageView({ data }: DataTableProps<Nodepool>) {
   const [edit, setEdit] = useState<boolean>(false)
   const [remove, setRemove] = useState<boolean>(false)
+  const [sorting, setSorting] = useState<SortingState>([])
+
+  console.log('Edit:', edit)
+  console.log('Remove:', remove)
 
   const columns: ColumnDef<Nodepool>[] = [
     {
@@ -115,6 +118,8 @@ export function PageView({ data }: DataTableProps<Nodepool>) {
         data={data}
         totalCount={data.length}
         expandable
+        sorting={sorting}
+        onSortingChange={setSorting}
         renderExpandedRow={(row) => (
           <TableRow className='contents'>
             <TableCell colSpan={columns.length} className='p-0' style={{ gridColumn: '1 / -1' }}>

--- a/apps/web/src/app/(protected)/clusters/[id]/node-pools/page-view.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/node-pools/page-view.tsx
@@ -7,6 +7,7 @@ import { DataTable } from '@/components/ui/data-table'
 import { Button } from '@/components/shadcn/button'
 import { PencilIcon, Plus, Trash } from 'lucide-react'
 import { TableCell, TableRow } from '@ror/react/components/table/table'
+import Link from 'next/link'
 
 interface Node {
   name: string
@@ -94,6 +95,15 @@ export function PageView({ data }: DataTableProps<Nodepool>) {
       accessorKey: 'memory',
       header: 'Memory',
       cell: ({ row }) => convertBytes(row.original.memory),
+    },
+    {
+      accessorKey: 'nodes',
+      header: 'Node links',
+      cell: () => (
+        <Link href='nodes' className='text-blue-500 dark:text-blue-600 hover:underline'>
+          Nodes
+        </Link>
+      ),
     },
     {
       accessorKey: 'actions',

--- a/apps/web/src/app/(protected)/clusters/[id]/node-pools/page-view.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/node-pools/page-view.tsx
@@ -5,7 +5,7 @@ import { ColumnDef, SortingState } from '@tanstack/react-table'
 import React, { useState } from 'react'
 import { DataTable } from '@/components/ui/data-table'
 import { Button } from '@/components/shadcn/button'
-import { PencilIcon, Trash } from 'lucide-react'
+import { PencilIcon, Plus, Trash } from 'lucide-react'
 import { TableCell, TableRow } from '@ror/react/components/table/table'
 
 interface Node {
@@ -113,6 +113,10 @@ export function PageView({ data }: DataTableProps<Nodepool>) {
 
   return (
     <div>
+      <Button>
+        <Plus />
+        Create nodepool
+      </Button>
       <DataTable
         columns={columns}
         data={data}

--- a/apps/web/src/app/(protected)/clusters/[id]/node-pools/page-view.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/node-pools/page-view.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import { convertBytes } from '@/utils/bytes'
+import { ColumnDef } from '@tanstack/react-table'
+// import {TableCell, TableRow } from "@/components/shadcn/table"
+import React, { useState } from 'react'
+import { DataTable } from '@/components/ui/data-table'
+import { Button } from '@/components/shadcn/button'
+import { PencilIcon, Trash } from 'lucide-react'
+import { TableCell, TableRow } from '@ror/react/components/table/table'
+
+interface Node {
+  name: string
+  role: string
+  image: string
+  architecture: string
+  cpu: string
+  memory: string
+}
+
+interface Nodepool {
+  name: string
+  machineClass: string
+  nodeCount: number
+  cores: number
+  memory: number
+  nodes: Node[]
+}
+
+const NodeCard = ({ node }: { node: Node }) => {
+  return (
+    <div className='rounded-lg border p-4 bg-[var(--r-layer)] dark:brightness-125 w-lg flex flex-col gap-2'>
+      <h4 className='font-semibold text-xl text-wrap'>{node.name}</h4>
+      <hr />
+      <p className='flex items-center'>
+        <span className='font-semibold'>Role: &nbsp;</span> {node.role}
+      </p>
+      <p className='flex items-center'>
+        <span className='font-semibold'>Image: &nbsp;</span> {node.image}
+      </p>
+      <p className='flex items-center'>
+        <span className='font-semibold'>Arch: &nbsp;</span> {node.architecture}
+      </p>
+      <p className='flex items-center'>
+        <span className='font-semibold'>CPU: &nbsp;</span> {node.cpu}
+      </p>
+      <p className='flex items-center'>
+        <span className='font-semibold'>Memory: &nbsp;</span> {node.memory}
+      </p>
+    </div>
+  )
+}
+
+interface DataTableProps<TData> {
+  data: TData[]
+}
+
+export function PageView({ data }: DataTableProps<Nodepool>) {
+  const [edit, setEdit] = useState<boolean>(false)
+  const [remove, setRemove] = useState<boolean>(false)
+
+  const columns: ColumnDef<Nodepool>[] = [
+    {
+      id: 'expander',
+      cell: ({ row }) =>
+        row.getCanExpand() ? (
+          <div className='inline-flex w-fit'>
+            <button onClick={row.getToggleExpandedHandler()} className='text-black dark:text-white'>
+              {row.getIsExpanded() ? '▼' : '▶'}
+            </button>
+          </div>
+        ) : null,
+    },
+    {
+      accessorKey: 'name',
+      header: 'Name',
+    },
+    {
+      accessorKey: 'machineClass',
+      header: 'Machine Class',
+    },
+    {
+      accessorKey: 'nodeCount',
+      header: 'Node Count',
+    },
+    {
+      accessorKey: 'cores',
+      header: 'Cores',
+    },
+    {
+      accessorKey: 'memory',
+      header: 'Memory',
+      cell: ({ row }) => convertBytes(row.original.memory),
+    },
+    {
+      accessorKey: 'actions',
+      header: 'Actions',
+      cell: () => (
+        <div className='flex gap-2'>
+          <Button className='flex gap-2' onClick={() => setEdit(true)}>
+            <PencilIcon className='h-5 w-5' />
+          </Button>
+          <Button className='flex gap-2' onClick={() => setRemove(true)} variant='destructive'>
+            <Trash className='h-5 w-5' />
+          </Button>
+        </div>
+      ),
+    },
+  ]
+
+  return (
+    <div>
+      <DataTable
+        columns={columns}
+        data={data}
+        totalCount={data.length}
+        expandable
+        renderExpandedRow={(row) => (
+          <TableRow className='contents'>
+            <TableCell colSpan={columns.length} className='p-0' style={{ gridColumn: '1 / -1' }}>
+              <div className='w-full bg-[var(--r-layer)] brightness-102 dark:brightness-110 px-4 py-4'>
+                <div className='flex flex-wrap gap-4'>
+                  {(row.original as Nodepool).nodes.map((node) => (
+                    <NodeCard key={node.name} node={node} />
+                  ))}
+                </div>
+              </div>
+            </TableCell>
+          </TableRow>
+        )}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/app/(protected)/clusters/[id]/node-pools/page.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/node-pools/page.tsx
@@ -1,7 +1,6 @@
 import { authGuard } from '@/features/auth/utils/auth-guard'
 import { rorApiClient } from '@/services/ror-api'
 import { PageView } from './page-view'
-
 interface NodePoolsPageProps {
   params: Promise<{ id: string }>
 }
@@ -84,6 +83,7 @@ export default async function NodePoolsPage({ params }: NodePoolsPageProps) {
   const response = await client.nodes.listByCluster(id)
 
   const nodes = response?.resources ?? []
+  console.log('Nodes:', nodes)
 
   return (
     <div>

--- a/apps/web/src/app/(protected)/clusters/[id]/node-pools/page.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/node-pools/page.tsx
@@ -1,10 +1,80 @@
 import { authGuard } from '@/features/auth/utils/auth-guard'
 import { rorApiClient } from '@/services/ror-api'
-import { NodePoolsDataView } from './node-pools-data-view'
+import { PageView } from './page-view'
 
 interface NodePoolsPageProps {
   params: Promise<{ id: string }>
 }
+
+interface Node {
+  name: string
+  role: string
+  image: string
+  architecture: string
+  cpu: string
+  memory: string
+}
+
+interface Nodepool {
+  name: string
+  machineClass: string
+  nodeCount: number
+  cores: number
+  memory: number
+  nodes: Node[]
+  actions: React.ReactNode
+}
+
+const npNodes: Node[] = [
+  {
+    name: 'aclusterkind-np-1-pgmsg-cvjvs-l7nqq',
+    role: 'worker',
+    image: 'VMware Photon OS/Linux',
+    architecture: 'amd64',
+    cpu: '11% (224 mi / 2)',
+    memory: '50% (3.91 GiB / 7.68 GiB)',
+  },
+  {
+    name: 'aclusterkind-np-1-pgmsg-cvjvs-qlw82',
+    role: 'worker',
+    image: 'VMware Photon OS/Linux',
+    architecture: 'amd64',
+    cpu: '6% (133 mi / 2)',
+    memory: '53% (4.11 GiB / 7.68 GiB)',
+  },
+]
+
+const workerNodes: Node[] = [
+  {
+    name: 'aclusterkind-workers-taint-xzxdr-bgjrh-7g2jt',
+    role: 'worker',
+    image: 'VMware Photon OS/Linux',
+    architecture: 'amd64',
+    cpu: '5% (107 mi / 2)',
+    memory: '31% (1.17 GiB / 3.74 GiB)',
+  },
+]
+
+const NodepoolExamples: Nodepool[] = [
+  {
+    name: 'Np',
+    machineClass: 'best-effort-medium',
+    nodeCount: 2,
+    cores: 4,
+    memory: 15360000000,
+    nodes: npNodes,
+    actions: <button className='text-blue-500 hover:underline'>Edit</button>,
+  },
+  {
+    name: 'Workers',
+    machineClass: 'best-effort-small',
+    nodeCount: 1,
+    cores: 2,
+    memory: 37400000000,
+    nodes: workerNodes,
+    actions: <button className='text-blue-500 hover:underline'>Edit</button>,
+  },
+]
 
 export default async function NodePoolsPage({ params }: NodePoolsPageProps) {
   const { id } = await params
@@ -17,7 +87,7 @@ export default async function NodePoolsPage({ params }: NodePoolsPageProps) {
 
   return (
     <div>
-      <NodePoolsDataView nodes={nodes} />
+      <PageView data={NodepoolExamples} />
     </div>
   )
 }

--- a/apps/web/src/app/(protected)/clusters/[id]/page.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { authGuard } from '@/features/auth/utils/auth-guard'
 import { rorApiClient } from '@/services/ror-api'
 import { ClusterDetails } from '@/components/ui/cluster/cluster-details'
+import { CodeSnippet } from '@ror/react'
 
 interface ClusterPageProps {
   params: Promise<{
@@ -22,6 +23,7 @@ export default async function ClusterPage({ params }: ClusterPageProps) {
 
   return (
     <div className='@container'>
+      <CodeSnippet type='single'>{session.accessToken}</CodeSnippet>
       <ClusterDetails cluster={cluster} />
     </div>
   )

--- a/apps/web/src/app/(protected)/clusters/[id]/page.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next'
 import { authGuard } from '@/features/auth/utils/auth-guard'
 import { rorApiClient } from '@/services/ror-api'
 import { ClusterDetails } from '@/components/ui/cluster/cluster-details'
-import { CodeSnippet } from '@ror/react'
 
 interface ClusterPageProps {
   params: Promise<{
@@ -23,7 +22,6 @@ export default async function ClusterPage({ params }: ClusterPageProps) {
 
   return (
     <div className='@container'>
-      <CodeSnippet type='single'>{session.accessToken}</CodeSnippet>
       <ClusterDetails cluster={cluster} />
     </div>
   )

--- a/apps/web/src/components/shadcn/button.tsx
+++ b/apps/web/src/components/shadcn/button.tsx
@@ -9,7 +9,8 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: 'bg-blue-500 dark:bg-blue-600 shadow-xs hover:bg-primary/90',
-        destructive: 'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20',
+        destructive:
+          'bg-red-500 dark:bg-red-600 text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20',
         outline: 'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground',
         secondary: 'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',

--- a/apps/web/src/components/ui/data-table/data-table.tsx
+++ b/apps/web/src/components/ui/data-table/data-table.tsx
@@ -16,7 +16,13 @@ import {
 import type { TableProps } from '@ror/react/components/table'
 import { Pagination } from '@ror/react/components/pagination'
 import { SortDirection } from '@ror/react/utils/sorting'
-import { flexRender, getCoreRowModel, getExpandedRowModel, useReactTable } from '@tanstack/react-table'
+import {
+  flexRender,
+  getCoreRowModel,
+  getExpandedRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
 import type { ColumnDef, Header, PaginationState, Row, SortingState } from '@tanstack/react-table'
 import { getItemRangeText } from './pagination'
 import { ChangeEvent, ChangeEventHandler, Fragment, useId } from 'react'
@@ -130,6 +136,7 @@ export function DataTable<TData>(props: DataTableProps<TData>) {
     columns,
     getCoreRowModel: getCoreRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
+    getSortedRowModel: getSortedRowModel(),
     getRowCanExpand: () => expandable,
 
     /**
@@ -225,6 +232,9 @@ export function DataTable<TData>(props: DataTableProps<TData>) {
 
   const hasTitleOrSubtitle = title || subtitle
 
+  // Only show pagination if there are more rows than the current page size
+  const showPagination = totalCount > paginationPageSize
+
   return (
     <Fragment>
       <TableContainer hasPagination>
@@ -306,39 +316,24 @@ export function DataTable<TData>(props: DataTableProps<TData>) {
                     <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
                   ))}
                 </TableRow>
-                {/* {row.getIsExpanded() && (
-                  <TableRow className=''>
-                    <TableCell
-                      style={{ gridColumn: `span ${table.getAllFlatColumns().length}` }}
-                      className='bg-[var(--r-layer)] brightness-102 dark:brightness-130'
-                    >
-                      {(row.original as Nodepool).nodes.map((node) => <NodeCard key={node.name} node={node} />)} */}
-                {/* Replace with your expanded content */}
-                {/* <div className="w-full bg-muted p-2 rounded">
-                        Expanded content here...
-                      </div>*/}
-                {/* </TableCell>  */}
-                {/* <td colSpan={7} className='bg-red-400'>
-                        <span className='bg-blue-400'>Test</span>
-                    </td> */}
-                {/* </TableRow> */}
-                {/* )} */}
                 {row.getIsExpanded() && props.renderExpandedRow?.(row)}
               </Fragment>
             ))}
           </TableBody>
         </Table>
       </TableContainer>
-      <Pagination
-        pageSize={paginationPageSize}
-        pageSizes={pageSizes}
-        onPageSizeChange={handleOnPageSizeChange}
-        itemRangeText={itemRangeText}
-        backwardsDisabled={!table.getCanPreviousPage()}
-        forwardsDisabled={!table.getCanNextPage()}
-        onBackwards={handleOnPaginationBackwards}
-        onForwards={handleOnPaginationForwards}
-      />
+      {showPagination && (
+        <Pagination
+          pageSize={paginationPageSize}
+          pageSizes={pageSizes}
+          onPageSizeChange={handleOnPageSizeChange}
+          itemRangeText={itemRangeText}
+          backwardsDisabled={!table.getCanPreviousPage()}
+          forwardsDisabled={!table.getCanNextPage()}
+          onBackwards={handleOnPaginationBackwards}
+          onForwards={handleOnPaginationForwards}
+        />
+      )}
     </Fragment>
   )
 }

--- a/apps/web/src/components/ui/data-table/data-table.tsx
+++ b/apps/web/src/components/ui/data-table/data-table.tsx
@@ -16,8 +16,8 @@ import {
 import type { TableProps } from '@ror/react/components/table'
 import { Pagination } from '@ror/react/components/pagination'
 import { SortDirection } from '@ror/react/utils/sorting'
-import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table'
-import type { ColumnDef, Header, PaginationState, SortingState } from '@tanstack/react-table'
+import { flexRender, getCoreRowModel, getExpandedRowModel, useReactTable } from '@tanstack/react-table'
+import type { ColumnDef, Header, PaginationState, Row, SortingState } from '@tanstack/react-table'
 import { getItemRangeText } from './pagination'
 import { ChangeEvent, ChangeEventHandler, Fragment, useId } from 'react'
 import { Layer } from '@ror/react'
@@ -93,6 +93,14 @@ export interface DataTableProps<TData> extends Omit<TableProps, 'gridTemplateCol
    * Callback for when the user changes the search query
    */
   onSearchChange?: (event: ChangeEvent<HTMLInputElement>) => void
+
+  /**
+   * If true, table will be expandable
+   * @default false
+   */
+  expandable?: boolean
+
+  renderExpandedRow?: (row: Row<TData>) => React.ReactNode
 }
 
 export function DataTable<TData>(props: DataTableProps<TData>) {
@@ -111,6 +119,7 @@ export function DataTable<TData>(props: DataTableProps<TData>) {
     onSortingChange,
     searchQuery,
     onSearchChange,
+    expandable = false,
   } = props
 
   const tableTitleId = useId()
@@ -120,6 +129,8 @@ export function DataTable<TData>(props: DataTableProps<TData>) {
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
+    getExpandedRowModel: getExpandedRowModel(),
+    getRowCanExpand: () => expandable,
 
     /**
      * The table needs information about the total number of rows and pages.
@@ -210,6 +221,8 @@ export function DataTable<TData>(props: DataTableProps<TData>) {
 
   const numberOfColumns = table.getAllColumns().length
   const gridTemplateColumns = `repeat(${numberOfColumns.toString()}, minmax(max-content, 1fr))`
+  const gridTemplateColumnsExpandable = `32px repeat(${numberOfColumns - 1}, minmax(max-content, 1fr))`
+
   const hasTitleOrSubtitle = title || subtitle
 
   return (
@@ -229,7 +242,10 @@ export function DataTable<TData>(props: DataTableProps<TData>) {
             )}
           </Layer>
         </TableToolbar>
-        <Table cellPadding={cellPadding} gridTemplateColumns={gridTemplateColumns}>
+        <Table
+          cellPadding={cellPadding}
+          gridTemplateColumns={expandable ? gridTemplateColumnsExpandable : gridTemplateColumns}
+        >
           <TableHead>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
@@ -284,11 +300,31 @@ export function DataTable<TData>(props: DataTableProps<TData>) {
           </TableHead>
           <TableBody>
             {table.getRowModel().rows.map((row) => (
-              <TableRow key={row.id}>
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
-                ))}
-              </TableRow>
+              <Fragment key={row.id}>
+                <TableRow>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+                  ))}
+                </TableRow>
+                {/* {row.getIsExpanded() && (
+                  <TableRow className=''>
+                    <TableCell
+                      style={{ gridColumn: `span ${table.getAllFlatColumns().length}` }}
+                      className='bg-[var(--r-layer)] brightness-102 dark:brightness-130'
+                    >
+                      {(row.original as Nodepool).nodes.map((node) => <NodeCard key={node.name} node={node} />)} */}
+                {/* Replace with your expanded content */}
+                {/* <div className="w-full bg-muted p-2 rounded">
+                        Expanded content here...
+                      </div>*/}
+                {/* </TableCell>  */}
+                {/* <td colSpan={7} className='bg-red-400'>
+                        <span className='bg-blue-400'>Test</span>
+                    </td> */}
+                {/* </TableRow> */}
+                {/* )} */}
+                {row.getIsExpanded() && props.renderExpandedRow?.(row)}
+              </Fragment>
             ))}
           </TableBody>
         </Table>

--- a/apps/web/src/components/ui/data-view/data-view.tsx
+++ b/apps/web/src/components/ui/data-view/data-view.tsx
@@ -70,7 +70,8 @@ export function DataView<TData>({ title, subtitle, table, cellPadding }: DataVie
   const hasTitleOrSubtitle = title || subtitle
 
   // Columns
-  const numberOfColumns = table.getAllColumns().length
+  if (!table) return null
+  const numberOfColumns = table?.getAllColumns?.().length ?? 0
   const gridTemplateColumns = `repeat(${numberOfColumns.toString()}, minmax(max-content, 1fr))`
 
   const tableState = table.getState()


### PR DESCRIPTION
This pull request introduces a new `PageView` component for managing and displaying node pools and nodes within a cluster, along with enhancements to the `DataTable` component to support expandable rows. Additionally, some minor UI updates and refactoring were performed to improve functionality and maintainability. Currently, this does not have any functionality. To make page usable, actual data has to be used (not just mock data), and links to other pages has to be added. 

### Node Pool and Node Management:
* Added a new `PageView` component in `apps/web/src/app/(protected)/clusters/[id]/node-pools/page-view.tsx` to display node pools with expandable rows showing detailed node information. This includes a `NodeCard` component for rendering individual node details. 
* Replaced the `NodePoolsDataView` with the new `PageView` component in `apps/web/src/app/(protected)/clusters/[id]/node-pools/page.tsx`. Added mock data for node pools (`NodepoolExamples`) and nodes (`npNodes`, `workerNodes`) for demonstration purposes. 

### Enhancements to `DataTable` Component:
* Updated `apps/web/src/components/ui/data-table/data-table.tsx` to support expandable rows with new props (`expandable` and `renderExpandedRow`) and logic for rendering expanded row content. 
* Integrated sorting and expanded row models (`getSortedRowModel`, `getExpandedRowModel`) into the `DataTable` component.

### UI and Styling Updates:
* Updated the `destructive` button variant in `apps/web/src/components/shadcn/button.tsx` to use a darker red background in dark mode for better visual consistency.

### Minor Fixes:
* Added a null check to the `DataView` component in `apps/web/src/components/ui/data-view/data-view.tsx` to handle cases where the `table` prop is not provided.