### PR TITLE
Adding saferails for when user does not have resources

### DIFF
--- a/apps/web/src/app/(protected)/clusters/page.tsx
+++ b/apps/web/src/app/(protected)/clusters/page.tsx
@@ -39,15 +39,6 @@ export default async function ClustersPage({ searchParams }: ClusterPageProps) {
   const response = await client.kubernetesClusters.list(listParams)
 
   const clusters: KubernetesCluster[] = response?.resources ?? []
-  console.debug('[ClusterPage] Clusters:', clusters)
-  console.debug(
-    '[ClusterPage] KubernetesClusters:',
-    clusters.map((c) => c.kubernetescluster)
-  )
-  console.dir(
-    clusters.map((c) => c.kubernetescluster),
-    { depth: null }
-  )
 
   return (
     <div className='w-full flex flex-col'>

--- a/apps/web/src/app/(protected)/clusters/page.tsx
+++ b/apps/web/src/app/(protected)/clusters/page.tsx
@@ -39,6 +39,15 @@ export default async function ClustersPage({ searchParams }: ClusterPageProps) {
   const response = await client.kubernetesClusters.list(listParams)
 
   const clusters: KubernetesCluster[] = response?.resources ?? []
+  console.debug('[ClusterPage] Clusters:', clusters)
+  console.debug(
+    '[ClusterPage] KubernetesClusters:',
+    clusters.map((c) => c.kubernetescluster)
+  )
+  console.dir(
+    clusters.map((c) => c.kubernetescluster),
+    { depth: null }
+  )
 
   return (
     <div className='w-full flex flex-col'>

--- a/packages/js-api-client/src/core/validation.ts
+++ b/packages/js-api-client/src/core/validation.ts
@@ -23,6 +23,19 @@ import { logValidationError } from './logger'
  */
 export function validateResponse<T>(data: unknown, schema: z.ZodType<T>): T {
   try {
+    // This solution handles the case where the data is an empty object,
+    // like when the user does not have access to any clusters.
+    // This could benefit from being fixed in the API, but for now we handle it here.
+    // TODO: Ask Håvard or Roger if this should be fixed in the API when they are back from holidays.
+    if (
+      typeof data === 'object' &&
+      data !== null &&
+      Object.keys(data).length === 0 &&
+      schema.safeParse({ resources: [] }).success
+    ) {
+      return schema.parse({ resources: [] })
+    }
+
     return schema.parse(data)
   } catch (error) {
     if (error instanceof z.ZodError) {


### PR DESCRIPTION
This pull request introduces a small but important change to the `validateResponse` function in `packages/js-api-client/src/core/validation.ts` to handle edge cases where the input data is an empty object. The change ensures compatibility with the schema by substituting an empty `resources` array when appropriate.

The issue was originally meant to implement next-auth with react 18, but this currently seems to be working. Will do more testing on it later.