### PR TITLE
Implement opening cluster in new tab

### DIFF
--- a/apps/web/src/components/ui/cluster/cluster-card.tsx
+++ b/apps/web/src/components/ui/cluster/cluster-card.tsx
@@ -112,7 +112,7 @@ const ClusterCard = ({ className, user, cluster, displayData }: ClusterCardProps
   const router = useRouter()
 
   const handleCardClick = () => {
-    router.push(`/clusters/${clusterId}`)
+    window.open(`/clusters/${clusterId}`, '_blank')
   }
 
   const envColor = envBgColors[env ?? 'undefined'] ?? ['bg-gray-100', 'text-gray-900']

--- a/apps/web/src/components/ui/cluster/cluster-card.tsx
+++ b/apps/web/src/components/ui/cluster/cluster-card.tsx
@@ -8,7 +8,6 @@ import type { KubernetesCluster } from '@ror/js-api-client'
 import { CodeSnippet, Layer } from '@ror/react'
 import { ExternalLink } from 'lucide-react'
 import { User } from 'next-auth'
-import { useRouter } from 'next/navigation'
 import { envBgColors } from './cluster-header'
 import { HealthCircle } from './health-circle'
 
@@ -108,8 +107,6 @@ const ClusterCard = ({ className, user, cluster, displayData }: ClusterCardProps
     clusterStatus?.state?.endpoints?.find((endpoint) => endpoint.name === 'datacenter')?.address || '<missing>'
   const rorLogin = `ror login ${clusterId}`
   const kubectlLogin = `kubectl vsphere login --server=${serverUrl} -u ${user?.email} --insecure-skip-tls-verify --tanzu-kubernetes-cluster-namespace ${clusterSpec?.data?.workspace} --tanzu-kubernetes-cluster-name ${clusterName}`
-
-  const router = useRouter()
 
   const handleCardClick = () => {
     window.open(`/clusters/${clusterId}`, '_blank')


### PR DESCRIPTION
This pull request modifies the `handleCardClick` function to open cluster links in a new browser tab instead of navigating within the current tab. 