### PR TITLE
Fix homepage link

### DIFF
--- a/apps/web/src/components/app-sidebar-header.tsx
+++ b/apps/web/src/components/app-sidebar-header.tsx
@@ -1,10 +1,14 @@
+import { routes } from '@/config/routes'
 import Image from 'next/image'
+import Link from 'next/link'
 import { SidebarHeader } from './shadcn/sidebar'
 
 export function AppSidebarHeader() {
   return (
     <SidebarHeader className='flex flex-row items-center'>
-      <Image src='/logo.svg' alt='Logo' width={40} height={40} className='w-10 h-fit scale-100' />
+      <Link href={routes.app.clusters.getHref()}>
+        <Image src='/logo.svg' alt='Logo' width={40} height={40} className='w-10 h-fit scale-100' />
+      </Link>
       <h1 className='text-4xl text-blue-900 dark:text-inherit font-semibold group-data-[collapsible=icon]:hidden'>
         ROR
       </h1>


### PR DESCRIPTION
This pull request updates the `AppSidebarHeader` component to enhance navigation by wrapping the logo in a link that directs users to the clusters page.