### PR TITLE
fix[mock]: comment out import, type and clusterHandler (v1)

### DIFF
--- a/apps/web/__mocks__/data/clusters.ts
+++ b/apps/web/__mocks__/data/clusters.ts
@@ -1,6 +1,4 @@
-import { sub } from 'date-fns'
 import { faker } from '@faker-js/faker'
-import nodes from './nodes'
 
 /**
  * Mock data for Clusters v1.

--- a/apps/web/__mocks__/handlers.ts
+++ b/apps/web/__mocks__/handlers.ts
@@ -1,7 +1,7 @@
-import { clustersHandlers } from './handlers/clusters'
+// import { clustersHandlers } from './handlers/clusters'
 import { v2ResourcesHandlers } from './handlers/v2-resources'
 
 /**
  * Mock handlers for the application.
  */
-export const handlers = [...clustersHandlers, ...v2ResourcesHandlers]
+export const handlers = [...v2ResourcesHandlers]

--- a/apps/web/__mocks__/handlers/clusters.ts
+++ b/apps/web/__mocks__/handlers/clusters.ts
@@ -1,10 +1,15 @@
+/**
+ * this fileset is an example to mock API handlers for for clusters v1 in the ROR web application
+ * this is not used in the current implementation, but kept for reference for v2
+ */
+
 import { http, HttpResponse } from 'msw'
 import { alphabetical } from 'radash'
 
-import { clustersVersion1 } from '../data/clusters'
+//import { clustersVersion1 } from '../data/clusters'
 import { createPaginatedResponse, type PaginatedResponse } from '../utils/paginated-response'
 import { getRorAPIPath } from '../utils/mock-base-url'
-type ClusterVersionOne = (typeof clustersVersion1)[number]
+//type ClusterVersionOne = (typeof clustersVersion1)[number]
 
 /**
  * The body of the request to filter clusters.
@@ -25,48 +30,48 @@ interface FilterBody {
  * Handler will not be used, as it is made for Cluster v1. It is kept here for reference.
  * Defines mock handlers for cluster-related API endpoints.
  */
-export const clustersHandlers = [
-  // Mock POST /v1/clusters/filter to filter, sort, and paginate clusters
-  http.post<never, FilterBody, PaginatedResponse<ClusterVersionOne>>(
-    getRorAPIPath('/v1/clusters/filter'), // Builds full mock path
-    async ({ request }) => {
-      // Parse the request body as JSON
-      const payload = await request.json()
+// export const clustersHandlers = [
+//   // Mock POST /v1/clusters/filter to filter, sort, and paginate clusters
+//   http.post<never, FilterBody, PaginatedResponse<ClusterVersionOne>>(
+//     getRorAPIPath('/v1/clusters/filter'), // Builds full mock path
+//     async ({ request }) => {
+//       // Parse the request body as JSON
+//       const payload = await request.json()
 
-      // Set default pagination values if not provided
-      const pagination = {
-        limit: payload?.limit ?? 10,
-        skip: payload?.skip ?? 0,
-      }
+//       // Set default pagination values if not provided
+//       const pagination = {
+//         limit: payload?.limit ?? 10,
+//         skip: payload?.skip ?? 0,
+//       }
 
-      // Start with a copy of all mock clusters
-      let filteredClusters = [...clustersVersion1]
+//       // Start with a copy of all mock clusters
+//       let filteredClusters = [...clustersVersion1]
 
-      // If sorting by 'clusterName' is requested, apply it using Radash
-      if (Array.isArray(payload?.sort) && payload.sort.length > 0 && payload.sort[0].sortField === 'clusterName') {
-        const sortOrder = payload.sort[0].sortOrder === -1 ? 'desc' : 'asc'
-        filteredClusters = alphabetical(clustersVersion1, (c) => c.clusterName, sortOrder)
-      }
+//       // If sorting by 'clusterName' is requested, apply it using Radash
+//       if (Array.isArray(payload?.sort) && payload.sort.length > 0 && payload.sort[0].sortField === 'clusterName') {
+//         const sortOrder = payload.sort[0].sortOrder === -1 ? 'desc' : 'asc'
+//         filteredClusters = alphabetical(clustersVersion1, (c) => c.clusterName, sortOrder)
+//       }
 
-      // Generate paginated response
-      const paginatedResponse = createPaginatedResponse(pagination, filteredClusters)
+//       // Generate paginated response
+//       const paginatedResponse = createPaginatedResponse(pagination, filteredClusters)
 
-      // Return the paginated response as JSON
-      return HttpResponse.json(paginatedResponse)
-    }
-  ),
+//       // Return the paginated response as JSON
+//       return HttpResponse.json(paginatedResponse)
+//     }
+//   ),
 
-  // Mock GET /v1/clusters/:clusterId to retrieve a single cluster by ID
-  http.get(getRorAPIPath('/v1/clusters/:clusterId'), ({ params }) => {
-    // Look up the cluster by its ID from the mock data
-    const singleCluster = clustersVersion1.find((c) => c.clusterId === params.clusterId)
+//   // Mock GET /v1/clusters/:clusterId to retrieve a single cluster by ID
+//   http.get(getRorAPIPath('/v1/clusters/:clusterId'), ({ params }) => {
+//     // Look up the cluster by its ID from the mock data
+//     const singleCluster = clustersVersion1.find((c) => c.clusterId === params.clusterId)
 
-    // If not found, return a 404 error
-    if (!singleCluster) {
-      return HttpResponse.json({ error: 'Cluster not found' }, { status: 404 })
-    }
+//     // If not found, return a 404 error
+//     if (!singleCluster) {
+//       return HttpResponse.json({ error: 'Cluster not found' }, { status: 404 })
+//     }
 
-    // Otherwise, return the cluster data as JSON
-    return HttpResponse.json(singleCluster)
-  }),
-]
+//     // Otherwise, return the cluster data as JSON
+//     return HttpResponse.json(singleCluster)
+//   }),
+// ]


### PR DESCRIPTION
fix after comment out clustersVersion1  from mock.

- removed clustersHandlers from handlers, and  comment out clustersHandlers, handler and import from handler.clusters.ts
- have ceept the file handler.clusters.ts as a reference 