### PR TITLE
Add preferences to localstorage and a toast

### DIFF
--- a/apps/web/src/components/ui/cluster/cluster-details.tsx
+++ b/apps/web/src/components/ui/cluster/cluster-details.tsx
@@ -1,20 +1,21 @@
 'use client'
 
+import { Button } from '@/components/shadcn/button'
+import { useClusterContext } from '@/context/cluster-context'
 import { cn } from '@/utils/clsxm'
-import { User } from 'next-auth'
-import React, { useState } from 'react'
-import { Responsive, WidthProvider } from 'react-grid-layout'
-import type { Layout, Layouts } from 'react-grid-layout'
-import 'react-grid-layout/css/styles.css'
-import 'react-resizable/css/styles.css'
-
-import { ExternalLink } from 'lucide-react'
+import { getSavedUserPreferenceObject, PREFERENCES_KEY, updateUserPreferenceObject } from '@/utils/user-preferences'
 import { Layer } from '@ror/react'
 import { format } from 'date-fns'
 import { enZA } from 'date-fns/locale'
-import { useClusterContext } from '@/context/cluster-context'
-import { Button } from '@/components/shadcn/button'
+import { ExternalLink } from 'lucide-react'
+import { User } from 'next-auth'
+import { useEffect, useState } from 'react'
+import type { Layout, Layouts } from 'react-grid-layout'
+import { Responsive, WidthProvider } from 'react-grid-layout'
+import 'react-grid-layout/css/styles.css'
+import 'react-resizable/css/styles.css'
 import { CodeSnippet } from '../code-snippet'
+import { toast } from 'sonner'
 
 const ResponsiveGridLayout = WidthProvider(Responsive)
 
@@ -135,6 +136,13 @@ export const ClusterDetails = ({ user, className }: ClusterDetailsProps) => {
     },
   }
 
+  useEffect(() => {
+    const preferences = getSavedUserPreferenceObject(PREFERENCES_KEY)
+    const layouts = preferences.clusterCards?.layouts || standardLayouts
+    setSavedLayouts(layouts)
+    setLayout(layouts[currentBreakpoint] || [])
+  }, [])
+
   const CardHeader = ({ title }: { title: string }) => {
     return (
       <div className='mb-2'>
@@ -149,10 +157,19 @@ export const ClusterDetails = ({ user, className }: ClusterDetailsProps) => {
       <div className='flex sm:flex-row flex-col gap-2 mb-3'>
         <Button
           onClick={() => {
-            setSavedLayouts((prev) => ({
-              ...prev,
+            const newLayouts = {
+              ...savedLayouts,
               [currentBreakpoint]: layout,
-            }))
+            }
+            setSavedLayouts(newLayouts)
+
+            updateUserPreferenceObject(PREFERENCES_KEY, {
+              clusterCards: {
+                layouts: newLayouts,
+              },
+            })
+
+            toast.info('Layout saved')
           }}
         >
           Save layout

--- a/apps/web/src/utils/user-preferences.ts
+++ b/apps/web/src/utils/user-preferences.ts
@@ -2,7 +2,9 @@
 
 import { z } from 'zod'
 
-const clusterCardSchema = z.object({})
+const clusterCardSchema = z.object({
+  layouts: z.record(z.string(), z.array(z.any())),
+})
 
 const userPreferencesSchema = z.object({
   key: z.string(),
@@ -14,11 +16,18 @@ const userPreferencesSchema = z.object({
 export type ClusterCard = z.infer<typeof clusterCardSchema>
 export type Preferences = z.infer<typeof userPreferencesSchema>
 
+function getInitialDarkMode(): boolean {
+  if (typeof window !== 'undefined') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+  }
+  return false // fallback during SSR
+}
+
 export const PREFERENCES_KEY = 'user-preferences'
 export const DEFAULT_USERPREFERENCES: Preferences = {
   key: PREFERENCES_KEY,
   language: 'nb',
-  darkMode: window.matchMedia('(prefers-color-scheme: dark)').matches,
+  darkMode: getInitialDarkMode(),
   clusterCards: {} as ClusterCard,
 }
 

--- a/packages/react/src/components/copy-button.tsx
+++ b/packages/react/src/components/copy-button.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { Copy } from 'lucide-react'
 import type { ReactNode } from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import { clsx } from 'clsx'
 import { Button, ButtonSize } from './button'
 import { toast } from 'sonner'
@@ -45,7 +45,6 @@ export interface CopyButtonProps {
 }
 export function CopyButton({ onClick, className, children, size = 'md' }: CopyButtonProps) {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
-  const [theme, setTheme] = useState<'light' | 'dark' | 'system'>('system')
 
   // Clean up timeout on unmount
   useEffect(() => {
@@ -54,20 +53,6 @@ export function CopyButton({ onClick, className, children, size = 'md' }: CopyBu
         clearTimeout(timeoutRef.current)
       }
     }
-  }, [])
-
-  // Determine theme on the client side
-  useEffect(() => {
-    const getTheme = () => {
-      if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        return 'dark'
-      } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
-        return 'light'
-      }
-      return 'system'
-    }
-
-    setTheme(getTheme())
   }, [])
 
   const handleOnClick = (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/packages/react/src/components/copy-button.tsx
+++ b/packages/react/src/components/copy-button.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { clsx } from 'clsx'
 import { Button, ButtonSize } from './button'
-import { toast, Toaster } from 'sonner'
+import { toast } from 'sonner'
 
 export interface CopyButtonProps {
   /**

--- a/packages/react/src/components/copy-button.tsx
+++ b/packages/react/src/components/copy-button.tsx
@@ -80,7 +80,6 @@ export function CopyButton({ onClick, className, children, size = 'md' }: CopyBu
 
   return (
     <>
-      <Toaster richColors position='bottom-right' theme={theme} />
       <Button icon={<Copy />} iconOnly onClick={handleOnClick} className={classes} size={size}>
         {children}
       </Button>


### PR DESCRIPTION
This pull request introduces enhancements to the `ClusterDetails` component and user preferences functionality, along with minor adjustments to improve maintainability. The key changes include enabling layout persistence for cluster cards, refactoring dark mode initialization, and removing an unused `Toaster` component.
