### PR TITLE
233 implement create nodepool api call

### DIFF
--- a/packages/js-api-client/src/services/__tests__/kubernetes-cluster.test.ts
+++ b/packages/js-api-client/src/services/__tests__/kubernetes-cluster.test.ts
@@ -9,7 +9,24 @@ const mockCluster: any = {
     spec: {
       topology: {
         workers: {
-          nodePools: [{ name: 'pool1' }, { name: 'pool2' }],
+          nodePools: [
+            {
+              name: 'pool1',
+              replicas: 10,
+              version: 'v1.27.3',
+              provider: 'azure',
+              machineClass: 'high-performance',
+              metadata: { labels: {}, annotations: {} },
+            },
+            {
+              name: 'pool2',
+              replicas: 5,
+              version: 'v1.27.3',
+              provider: 'azure',
+              machineClass: 'high-performance',
+              metadata: { labels: {}, annotations: {} },
+            },
+          ],
         },
       },
     },
@@ -34,7 +51,67 @@ describe('removeNodePool', () => {
             spec: expect.objectContaining({
               topology: expect.objectContaining({
                 workers: expect.objectContaining({
-                  nodePools: [{ name: 'pool2' }],
+                  nodePools: [
+                    {
+                      name: 'pool2',
+                      replicas: 5,
+                      version: 'v1.27.3',
+                      provider: 'azure',
+                      machineClass: 'high-performance',
+                      metadata: expect.any(Object),
+                    },
+                  ],
+                }),
+              }),
+            }),
+          }),
+        }),
+      })
+    )
+  })
+})
+
+describe('createOrUpdateNodePools', () => {
+  it('creates new node pools', async () => {
+    const request = jest
+      .fn()
+      .mockResolvedValueOnce(mockCluster) // GET
+      .mockResolvedValueOnce(mockCluster) // PUT
+
+    const service = createKubernetesClusterService(request as any)
+    await service.createOrUpdateNodePools('test-id', {
+      name: 'pool2',
+      machineClass: 'type1',
+      autoscaling: { enabled: true },
+    })
+
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'PUT',
+        body: expect.objectContaining({
+          kubernetescluster: expect.objectContaining({
+            spec: expect.objectContaining({
+              topology: expect.objectContaining({
+                workers: expect.objectContaining({
+                  nodePools: [
+                    {
+                      name: 'pool1',
+                      replicas: 10,
+                      version: 'v1.27.3',
+                      provider: 'azure',
+                      machineClass: 'high-performance',
+                      metadata: expect.any(Object),
+                    },
+                    {
+                      name: 'pool2',
+                      replicas: 5,
+                      version: 'v1.27.3',
+                      provider: 'azure',
+                      machineClass: 'type1',
+                      autoscaling: { enabled: true },
+                      metadata: expect.any(Object),
+                    },
+                  ],
                 }),
               }),
             }),

--- a/packages/js-api-client/src/services/kubernetes-cluster.ts
+++ b/packages/js-api-client/src/services/kubernetes-cluster.ts
@@ -20,6 +20,18 @@ export interface FilterRequestOptions {
   filter?: Filter[]
 }
 
+export interface NodePool {
+  name: string
+  replicas?: number
+  machineClass: string
+  labels?: Record<string, string>
+  taints?: { key: string; value: string; effect: string }[]
+  minSize?: number
+  maxSize?: number
+  diskSize?: number
+  autoscaling?: { enabled: boolean }
+}
+
 export const createKubernetesClusterService = (request: (requestOptions: RequestOptions) => Promise<unknown>) => ({
   /**
    * @deprecated use list instead
@@ -77,7 +89,7 @@ export const createKubernetesClusterService = (request: (requestOptions: Request
   },
 
   /**
-   * Nodepool API call
+   * Node pool API call
    */
 
   removeNodePool: async (id: string, poolName: string) => {
@@ -92,6 +104,39 @@ export const createKubernetesClusterService = (request: (requestOptions: Request
         (pool) => pool.name !== poolName
       )
     }
+    const res = await request({
+      method: 'PUT',
+      path: `/v2/resources/uid/${id}`,
+      body: cluster,
+    })
+
+    return validateResponse(res, KubernetesClusterSchema)
+  },
+  createOrUpdateNodePools: async (id: string, nodePool: NodePool) => {
+    if (!nodePool || !nodePool.name?.trim() || !nodePool.machineClass?.trim()) {
+      throw new Error('Node pool must have name and machineType')
+    }
+    const getRes = await request({
+      method: 'GET',
+      path: `/v2/resources/uid/${id}`,
+    })
+    const cluster = validateResponse(getRes, KubernetesClusterSchema)
+    const workers = cluster.kubernetescluster?.spec?.topology?.workers
+
+    if (!workers) {
+      throw new Error('Cluster does not have workers or nodePools defined')
+    }
+    const nodePools = workers.nodePools || []
+    const index = nodePools.findIndex((pool) => pool.name === nodePool.name)
+
+    if (index !== -1) {
+      // Update existing node pool
+      nodePools[index] = { ...nodePools[index], ...nodePool }
+    } else {
+      // Create new node pool
+      nodePools.push(nodePool)
+    }
+
     const res = await request({
       method: 'PUT',
       path: `/v2/resources/uid/${id}`,


### PR DESCRIPTION
Added `createOrUpdateNodePools` function
  - Creates new node pools or updates existing ones by name  
  - Handles both creation (push) and update (replace array element) workflows  
  
Strict, type-safe `NodePool` interface
  - Enforces required fields at compile time  
  - Prevents common runtime errors  
  
Comprehensive unit tests
- Includes a Jest test that test createOrUpdateNodePools
