### PR TITLE
Add refresh button

### DIFF
--- a/apps/web/src/app/(protected)/clusters/page-view.tsx
+++ b/apps/web/src/app/(protected)/clusters/page-view.tsx
@@ -275,8 +275,7 @@ export const PageView = ({ className, user, clusters, params }: PageViewProps) =
   }
 
   const clearUrl = () => {
-    router.push(pathname)
-    router.refresh()
+    router.replace(pathname, { scroll: false })
   }
 
   const handleRefreshFilters = () => {


### PR DESCRIPTION
This pull request enhances the cluster page view by introducing a user-friendly way to reset all applied filters and display selections. The main improvement is the addition of a "Refresh" button, which clears filter and display selections and resets the URL, making it easier for users to start a new search or view without residual filters. Supporting utility functions and state management have also been updated to ensure consistent behavior.

<img width="1720" height="744" alt="image" src="https://github.com/user-attachments/assets/1e6f38a4-4bc9-466f-9891-db07c7d438b6" />
