### PR TITLE
Set up in progress message on pages

### DIFF
--- a/apps/web/src/app/(protected)/clusters/[id]/layout.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/layout.tsx
@@ -5,6 +5,7 @@ import { Fragment, ReactNode, useEffect, useState } from 'react'
 import { routes } from '@/config/routes'
 import { ClusterHeader } from '@/components/ui/cluster/cluster-header'
 import { ClusterProvider } from '@/context/cluster-context'
+import { NotReadyMessage } from '@/components/ui/not-ready-message'
 // import { RenderApiError } from '@/utils/renderApiError'
 
 interface ClusterPageLayoutProps {
@@ -98,6 +99,9 @@ export default function ClusterPageLayout({ params, children }: ClusterPageLayou
         <div className='border-b'>
           <ClusterHeader tabs={tabs} />
         </div>
+        <NotReadyMessage className='mx-6 mt-8'>
+          The page is still under development, so some data and functionality is missing.
+        </NotReadyMessage>
         <div className='pt-2 px-6 md:px-6 md:pt-8'>{children}</div>
       </Fragment>
     </ClusterProvider>

--- a/apps/web/src/app/(protected)/clusters/page-view.tsx
+++ b/apps/web/src/app/(protected)/clusters/page-view.tsx
@@ -23,6 +23,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/shadcn/dropdown-menu'
 import type { WorkSheet } from 'xlsx'
+import { NotReadyMessage } from '@/components/ui/not-ready-message'
 
 interface Params {
   view?: 'grid' | 'list'
@@ -537,6 +538,12 @@ export const PageView = ({ className, user, clusters, params }: PageViewProps) =
         </div>
         {renderFilterSection()}
       </div>
+
+      <NotReadyMessage className='mx-12 my-6'>
+        Welcome to the new ROR web! This site is currently under development, so feel free to look around, but don't
+        expect finished functionality or that all data is present. The development team is working hard on delivering a
+        complete product as quick as possible :)
+      </NotReadyMessage>
 
       <section className='px-12 my-8'>
         {params.view === 'list' ? (

--- a/apps/web/src/app/(protected)/clusters/page-view.tsx
+++ b/apps/web/src/app/(protected)/clusters/page-view.tsx
@@ -540,7 +540,7 @@ export const PageView = ({ className, user, clusters, params }: PageViewProps) =
       </div>
 
       <NotReadyMessage className='mx-12 my-6'>
-        Welcome to the new ROR web! This site is currently under development, so feel free to look around, but don't
+        Welcome to the new ROR web! This site is currently under development, so feel free to look around, but do not
         expect finished functionality or that all data is present. The development team is working hard on delivering a
         complete product as quick as possible :)
       </NotReadyMessage>

--- a/apps/web/src/components/ui/cluster/cluster-header.tsx
+++ b/apps/web/src/components/ui/cluster/cluster-header.tsx
@@ -5,7 +5,6 @@ import { HealthCircle } from './health-circle'
 import { navigationItemObject } from '@/app/(protected)/clusters/[id]/layout'
 import { NavigationTabs } from '../navigation-tabs'
 import { useClusterContext } from '@/context/cluster-context'
-import { NotReadyMessage } from '../not-ready-message'
 
 interface ClusterHeaderProps {
   className?: string

--- a/apps/web/src/components/ui/cluster/cluster-header.tsx
+++ b/apps/web/src/components/ui/cluster/cluster-header.tsx
@@ -5,6 +5,7 @@ import { HealthCircle } from './health-circle'
 import { navigationItemObject } from '@/app/(protected)/clusters/[id]/layout'
 import { NavigationTabs } from '../navigation-tabs'
 import { useClusterContext } from '@/context/cluster-context'
+import { NotReadyMessage } from '../not-ready-message'
 
 interface ClusterHeaderProps {
   className?: string

--- a/apps/web/src/components/ui/not-ready-message.tsx
+++ b/apps/web/src/components/ui/not-ready-message.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { cn } from '@/utils/clsxm'
+import { X } from 'lucide-react'
+import { useState } from 'react'
+
+interface NotReadyMessageProps {
+  className?: string
+  children?: React.ReactNode
+}
+
+export const NotReadyMessage = ({ className, children }: NotReadyMessageProps) => {
+  const [isVisible, setIsVisible] = useState(true)
+
+  if (!isVisible) return null
+
+  return (
+    <div
+      className={cn(
+        className,
+        'p-5 border-3 rounded-lg flex flex-row items-center text-black',
+        'bg-orange-400 dark:bg-orange-500 border-orange-600 dark:border-orange-700'
+      )}
+    >
+      <div>{children}</div>
+      <button onClick={() => setIsVisible(false)}>
+        <X />
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/components/ui/not-ready-message.tsx
+++ b/apps/web/src/components/ui/not-ready-message.tsx
@@ -18,7 +18,7 @@ export const NotReadyMessage = ({ className, children }: NotReadyMessageProps) =
     <div
       className={cn(
         className,
-        'p-5 border-3 rounded-lg flex flex-row items-center text-black',
+        'p-5 border-3 rounded-lg flex flex-row justify-between items-center text-black',
         'bg-orange-400 dark:bg-orange-500 border-orange-600 dark:border-orange-700'
       )}
     >


### PR DESCRIPTION
This pull request introduces a new reusable `NotReadyMessage` component to display development status alerts across cluster-related pages. It also adds visible notifications to inform users that certain pages and features are still under development.