### PR TITLE
Add datacenter api call

### DIFF
--- a/packages/js-api-client/src/core/create-api-client.ts
+++ b/packages/js-api-client/src/core/create-api-client.ts
@@ -12,6 +12,7 @@ import { createVulnerabilityReportService } from '../services/vulnerability-repo
 import { createDaemonSetService } from '../services/deamon-sets'
 import { createReplicaSetService } from '../services/replica-sets'
 import { createPriceService } from '../services/prices'
+import { createDatacentersService } from '../services/datacenters'
 
 function setDefaultHeaders(config: ApiClientConfig): Record<string, string> {
   return {
@@ -40,18 +41,19 @@ export function createApiClient(config: ApiClientConfig) {
    * Create our different services
    */
   const services = {
+    configuration: createConfigurationService(request),
+    daemonSet: createDaemonSetService(request),
+    datacenter: createDatacentersService(request),
+    deployment: createDeploymentService(request),
+    ingresses: createIngressesService(request),
     kubernetesClusters: createKubernetesClusterService(request),
     nodes: createNodesService(request),
-    users: createUsersService(request),
-    ingresses: createIngressesService(request),
-    configuration: createConfigurationService(request),
-    deployment: createDeploymentService(request),
-    service: createServiceService(request),
-    daemonSet: createDaemonSetService(request),
-    replicaSet: createReplicaSetService(request),
-    vulnerabilityReport: createVulnerabilityReportService(request),
     pods: createPodsService(request),
     prices: createPriceService(request),
+    replicaSet: createReplicaSetService(request),
+    service: createServiceService(request),
+    users: createUsersService(request),
+    vulnerabilityReport: createVulnerabilityReportService(request),
   }
 
   return services

--- a/packages/js-api-client/src/index.ts
+++ b/packages/js-api-client/src/index.ts
@@ -18,6 +18,8 @@ export type {
   ConfigurationResponse,
   DaemonSet,
   DaemonSetResponse,
+  DataCenter,
+  DataCenterResponse,
   Deployment,
   DeploymentResponse,
   KubernetesCluster,

--- a/packages/js-api-client/src/schemas/datacenter.ts
+++ b/packages/js-api-client/src/schemas/datacenter.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod'
+import { createV2ResourceResponseSchema, V2ResourceSchema } from './common'
+
+const DatacenterLocationSchema = z.object({
+  id: z.string().nullable().optional(),
+  region: z.string().nullable().optional(),
+  country: z.string().nullable().optional(),
+})
+
+const DatacenterLegacySchema = z.object({
+  id: z.string().nullable().optional(),
+  name: z.string().nullable().optional(),
+  provider: z.string().nullable().optional(),
+  location: DatacenterLocationSchema.nullable().optional(),
+  apiEndpoint: z.string().nullable().optional(),
+})
+
+const WorkspaceSchema = z.object({
+  id: z.string().nullable().optional(),
+  name: z.string().nullable().optional(),
+  datacenterId: z.string().nullable().optional(),
+  datacenter: DatacenterLegacySchema.nullable().optional(),
+})
+
+const DatacenterSpecSchema = z.object({
+  workspaces: z.array(WorkspaceSchema).nullable().optional(),
+})
+
+const DatacenterStatusSchema = z.object({
+  workspaces: z.array(WorkspaceSchema),
+  location: DatacenterLocationSchema.nullable().optional(),
+  apiEndpoint: z.string().nullable().optional(),
+})
+
+export const DatacenterSchema = V2ResourceSchema.extend({
+  datacenter: z.object({
+    spec: DatacenterSpecSchema.nullable().optional(),
+    status: DatacenterStatusSchema.nullable().optional(),
+    legacy: DatacenterLegacySchema.nullable().optional(),
+  }),
+})
+
+export const DatacenterResponseSchema = createV2ResourceResponseSchema(DatacenterSchema)

--- a/packages/js-api-client/src/services/datacenters.ts
+++ b/packages/js-api-client/src/services/datacenters.ts
@@ -1,0 +1,19 @@
+import type { RequestOptions } from '../core/request'
+import { validateResponse } from '../core/validation'
+import { DatacenterResponseSchema } from '../schemas/datacenter'
+
+export const createDatacentersService = (request: (requestOptions: RequestOptions) => Promise<unknown>) => ({
+  list: async (urlParams: URLSearchParams) => {
+    const params = new URLSearchParams(urlParams)
+    params.set('apiversion', 'general.ror.internal/v1alpha1')
+    params.set('kind', 'Datacenter')
+
+    const response = await request({
+      method: 'GET',
+      path: '/v2/resources',
+      params,
+    })
+
+    return validateResponse(response, DatacenterResponseSchema)
+  },
+})

--- a/packages/js-api-client/src/types/entities.ts
+++ b/packages/js-api-client/src/types/entities.ts
@@ -18,6 +18,7 @@ import { ConfigurationSchema, configurationResponseSchema } from '../schemas/con
 import { VulnerabilityReportResponseSchema, VulnerabilityReportSchema } from '../schemas/vulnerability-report'
 import { RorMetaDataResponseSchema, RorMetaDataSchema } from '../schemas/common'
 import type { PriceResponseSchema, PriceSchema } from '../schemas/price'
+import type { DatacenterResponseSchema, DatacenterSchema } from '../schemas/datacenter'
 
 // "Cluster" matches the v1 resource
 export type Cluster = z.infer<typeof ClusterSchema>
@@ -27,6 +28,8 @@ export type Configuration = z.infer<typeof ConfigurationSchema>
 export type ConfigurationResponse = z.infer<typeof configurationResponseSchema>
 export type DaemonSet = z.infer<typeof DaemonSetSchema>
 export type DaemonSetResponse = z.infer<typeof DaemonSetResponseSchema>
+export type DataCenter = z.infer<typeof DatacenterSchema>
+export type DataCenterResponse = z.infer<typeof DatacenterResponseSchema>
 export type Deployment = z.infer<typeof DeploymentSchema>
 export type DeploymentResponse = z.infer<typeof DeploymentResponseSchema>
 export type Ingress = z.infer<typeof IngressSchema>


### PR DESCRIPTION
This pull request adds support for datacenter resources to the `js-api-client` package. The main changes include introducing schemas and types for datacenters, implementing a new datacenters service, and integrating this service into the API client. Additionally, the relevant types are exported for external use.