### PR TITLE
Update vulnerability-report in js-api-client

### DIFF
--- a/packages/js-api-client/src/schemas/vulnerability-report.ts
+++ b/packages/js-api-client/src/schemas/vulnerability-report.ts
@@ -2,42 +2,42 @@ import { z } from 'zod'
 import { createV2ResourceResponseSchema, V2ResourceSchema } from './common'
 
 const AquaReportSummary = z.object({
-  CriticalCount: z.number(),
-  HighCount: z.number(),
-  LowCount: z.number(),
-  MediumCount: z.number(),
-  Total: z.number().optional(),
+  criticalCount: z.number(),
+  highCount: z.number(),
+  lowCount: z.number(),
+  mediumCount: z.number(),
+  total: z.number().optional(),
 })
 
 const AquaReportScanner = z.object({
-  Name: z.string(),
-  Vendor: z.string(),
-  Version: z.string(),
+  name: z.string(),
+  vendor: z.string(),
+  version: z.string(),
 })
 
 const ResourceVulnerabilityReportReportArtifact = z.object({
-  Digest: z.string(),
-  Repository: z.string(),
-  Tag: z.string(),
+  digest: z.string(),
+  repository: z.string(),
+  tag: z.string(),
 })
 
 const ResourceVulnerabilityReportReportVulnerability = z.object({
-  VulnerabilityID: z.string(),
-  Severity: z.string(),
-  Score: z.number(),
-  Title: z.string(),
-  Resource: z.string(),
-  Link: z.string(),
-  InstalledVersion: z.string(),
-  FixedVersion: z.string(),
+  vulnerabilityID: z.string(),
+  severity: z.string(),
+  score: z.number(),
+  title: z.string(),
+  resource: z.string(),
+  primaryLink: z.string(),
+  installedVersion: z.string(),
+  fixedVersion: z.string(),
 })
 
 const VulnerabilityReportReportSchema = z.object({
-  Summary: AquaReportSummary,
-  Scanner: AquaReportScanner,
-  Artifact: ResourceVulnerabilityReportReportArtifact,
-  UpdateTimestamp: z.string(),
-  Vulnerabilities: z.array(ResourceVulnerabilityReportReportVulnerability),
+  summary: AquaReportSummary,
+  scanner: AquaReportScanner,
+  artifact: ResourceVulnerabilityReportReportArtifact,
+  updateTimestamp: z.string(),
+  vulnerabilities: z.array(ResourceVulnerabilityReportReportVulnerability),
 })
 
 export const VulnerabilityReportSchema = V2ResourceSchema.extend({


### PR DESCRIPTION
This pull request standardizes the property naming conventions in the `vulnerability-report.ts` Zod schemas to use camelCase instead of PascalCase. This improves code consistency and aligns with common JavaScript/TypeScript practices.