### PR TITLE
Add api call for projects

### DIFF
--- a/packages/js-api-client/src/core/create-api-client.ts
+++ b/packages/js-api-client/src/core/create-api-client.ts
@@ -16,6 +16,7 @@ import { createDatacentersService } from '../services/datacenters'
 import { createVirtualMachineService } from '../services/vm'
 import { createBackupJobService } from '../services/backup-job'
 import { createBackupRunService } from '../services/backup-run'
+import { createProjectService } from '../services/projects'
 
 function setDefaultHeaders(config: ApiClientConfig): Record<string, string> {
   return {
@@ -53,6 +54,7 @@ export function createApiClient(config: ApiClientConfig) {
     nodes: createNodesService(request),
     pods: createPodsService(request),
     prices: createPriceService(request),
+    projects: createProjectService(request),
     replicaSet: createReplicaSetService(request),
     service: createServiceService(request),
     users: createUsersService(request),

--- a/packages/js-api-client/src/schemas/project.ts
+++ b/packages/js-api-client/src/schemas/project.ts
@@ -1,0 +1,32 @@
+import z from 'zod'
+import { createPaginationSchema } from './common'
+
+export const ProjectSchema = z
+  .object({
+    active: z.boolean(),
+    created: z.string(),
+    description: z.string(),
+    id: z.string(),
+    name: z.string(),
+    projectMetadata: z.object({
+      billing: z.object({
+        workorder: z.string(),
+      }),
+      roles: z.array(
+        z.object({
+          contactInfo: z.object({
+            email: z.string(),
+            phone: z.string(),
+            upn: z.string(),
+          }),
+          roleDefinition: z.string(),
+        })
+      ),
+      serviceTags: z.array(z.record(z.string(), z.string())),
+    }),
+    updated: z.string(),
+  })
+  .passthrough()
+
+export const ProjectListSchema = z.array(ProjectSchema)
+export const ProjectResponseSchema = createPaginationSchema(ProjectSchema)

--- a/packages/js-api-client/src/services/projects.ts
+++ b/packages/js-api-client/src/services/projects.ts
@@ -1,0 +1,22 @@
+import type { RequestOptions } from '../core/request'
+import { validateResponse } from '../core/validation'
+import { ProjectListSchema } from '../schemas/project'
+
+export const createProjectService = (request: (requestOptions: RequestOptions) => Promise<unknown>) => ({
+  list: async () => {
+    const response = await request({
+      method: 'POST',
+      path: '/v1/projects/filter',
+      body: {
+        body: {
+          filters: [],
+          globalFilter: '',
+          limit: 0,
+          skip: 0,
+          sort: [],
+        },
+      },
+    })
+    return validateResponse(response, ProjectListSchema)
+  },
+})

--- a/packages/js-api-client/src/types/entities.ts
+++ b/packages/js-api-client/src/types/entities.ts
@@ -22,6 +22,7 @@ import type { PriceResponseSchema, PriceSchema } from '../schemas/price'
 import type { DatacenterResponseSchema, DatacenterSchema } from '../schemas/datacenter'
 import type { BackupJobSchema } from '../schemas/backup-job'
 import type { BackupRunSchema } from '../schemas/backup-run'
+import type { ProjectResponseSchema, ProjectSchema } from '../schemas/project'
 
 // "Cluster" matches the v1 resource
 export type Cluster = z.infer<typeof ClusterSchema>
@@ -47,13 +48,12 @@ export type Node = z.infer<typeof NodeSchema>
 export type NodeResponse = z.infer<typeof NodeResponseSchema>
 export type Price = z.infer<typeof PriceSchema>
 export type PriceResponse = z.infer<typeof PriceResponseSchema>
+export type Project = z.infer<typeof ProjectSchema>
+export type ProjectResponse = z.infer<typeof ProjectResponseSchema>
 export type Pod = z.infer<typeof PodSchema>
 export type PodResponse = z.infer<typeof PodResponseSchema>
 export type ReplicaSet = z.infer<typeof ReplicaSetSchema>
 export type ReplicaSetResponse = z.infer<typeof ReplicaSetResponseSchema>
-// Delete if no errors
-// export type Replicaset = z.infer<typeof ReplicaSetSchema>
-// export type ReplicasetResponse = z.infer<typeof ReplicaSetResponseSchema>
 export type RorMetaData = z.infer<typeof RorMetaDataSchema>
 export type RorMetaDataResponse = z.infer<typeof RorMetaDataResponseSchema>
 export type Service = z.infer<typeof ServiceSchema>


### PR DESCRIPTION
This pull request adds support for the "Project" entity to the JS API client, including its schema, service, and type definitions. The changes enable listing projects via the API and make project types available throughout the client.