### PR TITLE
Remove fields from cluster cards and update buttons on cards

### DIFF
--- a/apps/web/src/app/(protected)/clusters/page-view.tsx
+++ b/apps/web/src/app/(protected)/clusters/page-view.tsx
@@ -29,7 +29,7 @@ import { DataTable } from '@/components/ui/data-table'
 import { NotReadyMessage } from '@/components/ui/not-ready-message'
 import { ClusterCard } from '@/features/cluster/components/cluster-card'
 import { ClusterFilterSection } from '@/features/cluster/components/cluster-filter-section'
-import { displayDataOptions, sortingOptions } from '@/features/cluster/config/page-view-options'
+import { defaultDisplayData, displayDataOptions, sortingOptions } from '@/features/cluster/config/page-view-options'
 import { useDisplayData } from '@/hooks/use-display-data'
 import { ClusterCardDisplayData } from '@/features/cluster/types/display-data'
 import {
@@ -184,42 +184,34 @@ export const PageView = ({ className, clusters, params }: PageViewProps) => {
     return sortedItems.filter((c) => ids.has(getClusterIdView(c)))
   }, [sortedItems, searchResults])
 
-  // Grid and table view
-  const GridView = () => {
-    return (
-      <div>
-        <div className='flex flex-row flex-wrap gap-6'>
-          {displayedItems.map((cluster, idx) => (
-            <div key={getClusterIdView(cluster) || idx}>
-              <ClusterCard
-                cluster={cluster}
-                displayData={
-                  selectedDisplayData?.length > 0
-                    ? selectedDisplayData
-                    : displayDataOptions?.map((o) => o.value as ClusterCardDisplayData) || []
-                }
-              />
-            </div>
-          ))}
-          <div ref={sentinelRef} className='h-px' />
-        </div>
-        {isLoading && <div style={{ textAlign: 'center', padding: 16 }}>Loading...</div>}
-        {!hasMore && <div style={{ textAlign: 'center', padding: 16, color: '#888' }}>All clusters are loaded.</div>}
-      </div>
-    )
-  }
+  const effectiveDisplayData = (
+    selectedDisplayData?.length > 0 ? selectedDisplayData : defaultDisplayData
+  ) as ClusterCardDisplayData[]
 
-  const TableView = () => {
-    return (
-      <DataTable
-        data={displayedItems}
-        columns={getClustersTableColumns(selectedDisplayData)}
-        hasMore={hasMore}
-        isLoading={isLoading}
-        sentinelRef={sentinelRef}
-      />
-    )
-  }
+  const GridView = () => (
+    <div>
+      <div className='flex flex-row flex-wrap gap-6'>
+        {displayedItems.map((cluster, idx) => (
+          <div key={getClusterIdView(cluster) || idx}>
+            <ClusterCard cluster={cluster} displayData={effectiveDisplayData} />
+          </div>
+        ))}
+        <div ref={sentinelRef} className='h-px' />
+      </div>
+      {isLoading && <div style={{ textAlign: 'center', padding: 16 }}>Loading...</div>}
+      {!hasMore && <div style={{ textAlign: 'center', padding: 16, color: '#888' }}>All clusters are loaded.</div>}
+    </div>
+  )
+
+  const TableView = () => (
+    <DataTable
+      data={displayedItems}
+      columns={getClustersTableColumns(effectiveDisplayData)}
+      hasMore={hasMore}
+      isLoading={isLoading}
+      sentinelRef={sentinelRef}
+    />
+  )
 
   return (
     <div className={cn(className, '@container')}>

--- a/apps/web/src/components/shadcn/button.tsx
+++ b/apps/web/src/components/shadcn/button.tsx
@@ -17,6 +17,9 @@ const buttonVariants = cva(
         secondary: 'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
+        argocd: 'bg-[#4141e1] dark:bg-[#4141e1] shadow-xs hover:[#2c2cc7] dark:hover:bg-[#2c2cc7]',
+        grafana: 'bg-[#ff671d] dark:bg-[#ff671d] shadow-xs hover:[#e05009] dark:hover:bg-[#e05009]',
+        rorcli: 'bg-[#04d607] dark:bg-[#04d607] shadow-xs hover:[#04b306] dark:hover:bg-[#04b306]',
       },
       size: {
         default: 'h-9 px-4 py-2 has-[>svg]:px-3',

--- a/apps/web/src/components/shadcn/button.tsx
+++ b/apps/web/src/components/shadcn/button.tsx
@@ -17,9 +17,9 @@ const buttonVariants = cva(
         secondary: 'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
-        argocd: 'bg-[#4141e1] dark:bg-[#4141e1] shadow-xs hover:[#2c2cc7] dark:hover:bg-[#2c2cc7]',
-        grafana: 'bg-[#ff671d] dark:bg-[#ff671d] shadow-xs hover:[#e05009] dark:hover:bg-[#e05009]',
-        rorcli: 'bg-[#04d607] dark:bg-[#04d607] shadow-xs hover:[#04b306] dark:hover:bg-[#04b306]',
+        argocd: 'bg-[#4141e1] dark:bg-[#4141e1] shadow-xs hover:bg-[#2c2cc7] dark:hover:bg-[#2c2cc7]',
+        grafana: 'bg-[#ff671d] dark:bg-[#ff671d] shadow-xs hover:bg-[#e05009] dark:hover:bg-[#e05009]',
+        rorcli: 'bg-[#04d607] dark:bg-[#04d607] shadow-xs hover:bg-[#04b306] dark:hover:bg-[#04b306]',
       },
       size: {
         default: 'h-9 px-4 py-2 has-[>svg]:px-3',

--- a/apps/web/src/features/cluster/components/cluster-card.tsx
+++ b/apps/web/src/features/cluster/components/cluster-card.tsx
@@ -142,15 +142,23 @@ function externalLinkNum(shows: (...keys: ClusterCardDisplayData[]) => boolean):
   return colsMap[count] ?? 'grid-cols-3'
 }
 
-function ExternalTool({ name, url }: { name: string; url: string | null | undefined }) {
+function ExternalTool({
+  name,
+  type,
+  url,
+}: {
+  name: string
+  type: 'argocd' | 'grafana'
+  url: string | null | undefined
+}) {
   if (!url)
     return (
-      <Button variant='argocd' disabled className='font-bold'>
+      <Button variant={type} disabled className='font-bold'>
         <ExternalLink className='w-5 h-5' /> {name}
       </Button>
     )
   return (
-    <Button variant='argocd' className='font-bold' asChild>
+    <Button variant={type} className='font-bold' asChild>
       <a href={url} target='_blank' rel='noopener noreferrer' onClick={(e) => e.stopPropagation()}>
         <ExternalLink className='w-5 h-5' /> {name}
       </a>
@@ -302,8 +310,8 @@ const ClusterCard = ({ className, cluster, displayData }: ClusterCardProps) => {
         {shows('argocd', 'grafana', 'rorcli') && (
           <>
             <section className={cn('grid gap-2', externalLinkNum(shows))}>
-              {shows('argocd') && <ExternalTool name='ArgoCD' url={argocdUrl} />}
-              {shows('grafana') && <ExternalTool name='Grafana' url={grafanaUrl} />}
+              {shows('argocd') && <ExternalTool name='ArgoCD' type='argocd' url={argocdUrl} />}
+              {shows('grafana') && <ExternalTool name='Grafana' type='grafana' url={grafanaUrl} />}
               {shows('rorcli') && (
                 <Button
                   variant='rorcli'

--- a/apps/web/src/features/cluster/components/cluster-card.tsx
+++ b/apps/web/src/features/cluster/components/cluster-card.tsx
@@ -5,9 +5,7 @@ import * as React from 'react'
 import { Pill } from '@/components/shadcn/pill'
 import { cn } from '@/utils/clsxm'
 import type { ClusterListViewRowType } from '@ror/js-api-client'
-import { Layer } from '@ror/react'
-import { Dot, ExternalLink } from 'lucide-react'
-import { CodeSnippet } from '../../../components/ui/code-snippet'
+import { Copy, Dot, ExternalLink } from 'lucide-react'
 import type { ClusterCardDisplayData } from '../types/display-data'
 import {
   getArgocdUrlView,
@@ -46,6 +44,8 @@ import { useRouter } from 'next/navigation'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/shadcn/tooltip'
 import { Progress } from '@/components/shadcn/progress'
 import { negativeColors } from '@/utils/scale-colors'
+import { Button } from '@/components/shadcn/button'
+import { copyToClipboard } from '@/utils/copy-to-clipboard'
 
 function Card({ className, ...props }: React.ComponentProps<'div'>) {
   return (
@@ -77,6 +77,90 @@ interface ClusterCardProps {
   displayData?: ClusterCardDisplayData[]
 }
 
+function getPriceString(monthly: number | null | undefined, yearly: number | null | undefined): string {
+  const m = monthly ?? (yearly ? yearly / 12 : null)
+  const y = yearly ?? (monthly ? monthly * 12 : null)
+
+  if (!m && !y) return missingText
+  return `${m} kr / ${y} kr`
+}
+
+function displayDataContains(
+  displayData: ClusterCardDisplayData[] | undefined,
+  ...keys: ClusterCardDisplayData[]
+): boolean {
+  return keys.some((k) => displayData?.includes(k))
+}
+
+function Info({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div>
+      <p className='font-bold'>{label}</p>
+      <p>{value}</p>
+    </div>
+  )
+}
+
+interface ResourceCardProps {
+  label: string
+  resource: { capacity?: string; used?: string; percentage?: number | null }
+}
+
+function ResourceCard({ label, resource }: ResourceCardProps) {
+  const barColor = negativeColors(resource.percentage ?? 0).join(' ')
+  return (
+    <div>
+      <p className='font-bold'>{label}</p>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className='flex items-center'>
+            <Progress value={resource.percentage ?? 0} indicatorColor={barColor} className='flex-1 mr-1' />
+            <span className='w-10 text-right text-sm text-muted-foreground tabular-nums'>
+              {resource.percentage == null ? '—' : `${resource.percentage.toFixed(0)}%`}
+            </span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Used: {resource.used ?? 'data missing'}</p>
+          <p>Capacity: {resource.capacity ?? 'data missing'}</p>
+          <p>Percentage: {resource.percentage != null ? `${resource.percentage}%` : 'data missing'}</p>
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  )
+}
+
+const colsMap: Record<number, string> = {
+  0: 'grid-cols-1',
+  1: 'grid-cols-1',
+  2: 'grid-cols-2',
+  3: 'grid-cols-3',
+}
+
+function externalLinkNum(shows: (...keys: ClusterCardDisplayData[]) => boolean): string {
+  const count = (['argocd', 'grafana', 'rorcli'] as ClusterCardDisplayData[]).filter((k) => shows(k)).length
+  return colsMap[count] ?? 'grid-cols-3'
+}
+
+function ExternalTool({ name, url }: { name: string; url: string | null | undefined }) {
+  if (!url)
+    return (
+      <Button variant='argocd' disabled className='font-bold'>
+        <ExternalLink className='w-5 h-5' /> {name}
+      </Button>
+    )
+  return (
+    <Button variant='argocd' className='font-bold' asChild>
+      <a href={url} target='_blank' rel='noopener noreferrer' onClick={(e) => e.stopPropagation()}>
+        <ExternalLink className='w-5 h-5' /> {name}
+      </a>
+    </Button>
+  )
+}
+
+const infoSectionCls =
+  'flex flex-col gap-1.5 [&>div]:grid [&>div]:grid-cols-2 [@container(max-width:360px)]:[&>div]:grid-cols-1'
+
 /**
  * Renders a card displaying detailed information about a Kubernetes cluster.
  *
@@ -88,8 +172,6 @@ interface ClusterCardProps {
  * @returns A clickable card component linking to the cluster details page.
  */
 const ClusterCard = ({ className, cluster, displayData }: ClusterCardProps) => {
-  // const clusterUid = getClusterUidView(cluster)
-  // const clusterId = getClusterIdView(cluster)
   const clusterName = getClusterNameView(cluster) || missingText
   const provider = getProviderView(cluster) || missingText
   const datacenter = getDatacenterView(cluster) || missingText
@@ -114,158 +196,20 @@ const ClusterCard = ({ className, cluster, displayData }: ClusterCardProps) => {
   const kubernetesVersion = getKubernetesVersionView(cluster) || missingText
   const nhnToolingVersion = getNhnToolVersionView(cluster) || missingText
   const serviceId = getServiceIdView(cluster) || missingText
-  // const serviceTags = getTagsView(cluster) || []
   const healthCondition = getStatusView(cluster)
-  // const created = getCreatedView(cluster)
-  // const lastSeen = getLastSeenView(cluster)
+  // TODO: implement tags when view has tags
+  // const serviceTags = getTagsView(cluster) || []
 
   const rorLogin = getRorLoginView(cluster)
   const envColor = getHighDifferenceEnvironmentColors(env as Environment)
 
-  let priceString = ''
-
-  if (monthlyPrices && yearlyPrices) {
-    priceString = monthlyPrices + ' kr/' + yearlyPrices + ' kr'
-  } else if (monthlyPrices && !yearlyPrices) {
-    priceString = monthlyPrices + ' kr/' + monthlyPrices * 12 + ' kr'
-  } else if (!monthlyPrices && yearlyPrices) {
-    priceString = yearlyPrices / 12 + ' kr/' + yearlyPrices * 12 + ' kr'
-  } else {
-    priceString = missingText
-  }
-
-  const Argo = () => {
-    return argocdUrl ? (
-      <a
-        onClick={(e) => e.stopPropagation()}
-        href={`https://${argocdUrl}`}
-        target='_blank'
-        rel='noopener noreferrer'
-        className='flex gap-2 font-bold text-blue-500 w-fit'
-      >
-        <span>ArgoCD</span>
-        <ExternalLink className='w-5 h-5' />
-      </a>
-    ) : (
-      <p className='flex [@container(max-width:360px)]:flex-col'>
-        <span className='font-bold'>ArgoCD &nbsp;</span>
-        <span>missing ...</span>
-      </p>
-    )
-  }
-
-  const Grafana = () => {
-    return grafanaUrl ? (
-      <a
-        onClick={(e) => e.stopPropagation()}
-        href={`https://${grafanaUrl}`}
-        target='_blank'
-        rel='noopener noreferrer'
-        className='flex gap-2 font-bold text-blue-500 w-fit'
-      >
-        <span>Grafana</span>
-        <ExternalLink className='w-5 h-5' />
-      </a>
-    ) : (
-      <p className='flex [@container(max-width:360px)]:flex-col '>
-        <span className='font-bold'>Grafana &nbsp;</span>
-        <span>missing ...</span>
-      </p>
-    )
-  }
-
-  const Tools = () => {
-    return (
-      <section className='grid grid-cols-2'>
-        {displayData?.includes('argocd') && <Argo />}
-        {displayData?.includes('grafana') && <Grafana />}
-      </section>
-    )
-  }
-
-  const CodeSnippetLogins = () => {
-    return (
-      <section className='flex flex-col gap-1.5 [&>div]:gap-0.5'>
-        {displayData?.includes('rorcli') && (
-          <div>
-            <p className='font-bold'>ROR CLI</p>
-            <Layer level={2}>
-              <CodeSnippet type='single'>{rorLogin}</CodeSnippet>
-            </Layer>
-          </div>
-        )}
-      </section>
-    )
-  }
-
-  const ResourceCard = ({
-    label,
-    resource,
-  }: {
-    label: string
-    resource: { capacity?: string; used?: string; percentage?: number | null }
-  }) => {
-    const barColor = negativeColors(resource.percentage ?? 0).join(' ')
-
-    return (
-      <div>
-        <p className='font-bold'>{label}</p>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className='flex items-center'>
-              <Progress value={resource.percentage ?? 0} indicatorColor={barColor} className='flex-1 mr-1' />
-              <span className='w-10 text-right text-sm text-muted-foreground tabular-nums'>
-                {resource.percentage == null ? '—' : `${resource.percentage.toFixed(0)}%`}
-              </span>
-            </div>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Used: {resource.used ? resource.used : 'data missing'}</p>
-            <p>Capacity: {resource.capacity ? resource.capacity : 'data missing'}</p>
-            <p>Percentage: {resource.percentage ? resource.percentage + '%' : 'data missing'}</p>
-          </TooltipContent>
-        </Tooltip>
-      </div>
-    )
-  }
-
-  const Info = ({ label, value }: { label: string; value: string | number }) => {
-    return (
-      <div>
-        <p className='font-bold'>{label}</p>
-        <p>{value}</p>
-      </div>
-    )
-  }
-
-  const ServiceTags = () => {
-    return displayData?.includes('serviceTags') ? (
-      <div>
-        <p className='font-bold'>Tags</p>
-        <p className='flex flex-wrap gap-1'>
-          {/* {serviceTags.map(
-            ({ key, value, properties }: { key: string; value: string; properties: Record<string, string> }) => (
-              <Pill key={key} style={{ backgroundColor: properties.color }}>
-                {value}
-              </Pill>
-            )
-          )} */}
-        </p>
-      </div>
-    ) : null
-  }
+  const shows = (...keys: ClusterCardDisplayData[]) => displayDataContains(displayData, ...keys)
 
   const basicItems: React.ReactNode[] = []
 
-  if (displayData?.includes('datacenterProvider') && provider) {
-    basicItems.push(<span key='provider'>{provider}</span>)
-  }
+  if (shows('datacenterProvider') && provider) basicItems.push(<span key='provider'>{provider}</span>)
 
-  // if (displayData?.includes('datacenterName') && datacenter) {
-  //   basicItems.push(<span key='datacenter'>{datacenter}</span>)
-  // }
-
-  if (displayData?.includes('environment')) {
+  if (shows('environment')) {
     basicItems.push(
       <Pill key='environment' variant={envColors[(env ?? 'undefined') as Environment]} className='px-3'>
         {(env ?? 'Undefined').charAt(0).toUpperCase() + (env ?? 'Undefined').slice(1)}
@@ -273,7 +217,7 @@ const ClusterCard = ({ className, cluster, displayData }: ClusterCardProps) => {
     )
   }
 
-  basicItems.push(<span key='datacenter'>{datacenter}</span>)
+  if (shows('datacenterName')) basicItems.push(<span key='datacenter'>{datacenter}</span>)
 
   const router = useRouter()
 
@@ -306,73 +250,97 @@ const ClusterCard = ({ className, cluster, displayData }: ClusterCardProps) => {
       </CardHeader>
 
       <CardContent className='text-sm flex flex-col gap-3'>
-        <section className='flex items-center gap-2'>
-          {basicItems.map((item, index) => (
-            <React.Fragment key={index}>
-              {index > 0 && <Dot />}
-              {item}
-            </React.Fragment>
-          ))}
-        </section>
+        {basicItems.length > 0 && (
+          <>
+            <section className='flex items-center gap-2'>
+              {basicItems.map((item, index) => (
+                <React.Fragment key={index}>
+                  {index > 0 && <Dot />}
+                  {item}
+                </React.Fragment>
+              ))}
+            </section>
+            <hr />
+          </>
+        )}
 
-        <hr />
+        {shows('nodes', 'cpu', 'memory', 'price', 'workspace') && (
+          <>
+            <section className={infoSectionCls}>
+              {shows('nodes') && (
+                <Info label='Nodes' value={`${nodesAmount} (${nodePools} pool${nodePools !== 1 ? 's' : ''})`} />
+              )}
+              {shows('cpu') && (
+                <ResourceCard
+                  label={'CPU'}
+                  resource={{
+                    capacity: cpu,
+                    used: cpuUsedMilli,
+                    percentage: cpuUsedPercentNumber,
+                  }}
+                />
+              )}
+              {shows('memory') && (
+                <ResourceCard
+                  label={'Memory'}
+                  resource={{
+                    capacity: memory,
+                    used: memoryUsed,
+                    percentage: memoryUsedPercentNumber,
+                  }}
+                />
+              )}
+              {shows('price') && (
+                <Info label='Price (month/year)' value={getPriceString(monthlyPrices, yearlyPrices)} />
+              )}
+              {shows('workspace') && <Info label='Workspace' value={workspace} />}
+            </section>
+            <hr />
+          </>
+        )}
 
-        <section className='flex flex-col gap-1.5 [&>div]:grid [&>div]:grid-cols-2 [@container(max-width:360px)]:[&>div]:grid-cols-1'>
-          {displayData?.includes('nodes') && (
-            <Info label='Nodes' value={`${nodesAmount} (${nodePools} pool${nodePools !== 1 ? 's' : ''})`} />
-          )}
-          {displayData?.includes('cpu') && (
-            <ResourceCard
-              label={'CPU'}
-              resource={{
-                capacity: cpu,
-                used: cpuUsedMilli,
-                percentage: cpuUsedPercentNumber,
-              }}
-            />
-          )}
-          {displayData?.includes('memory') && (
-            <ResourceCard
-              label={'Memory'}
-              resource={{
-                capacity: memory,
-                used: memoryUsed,
-                percentage: memoryUsedPercentNumber,
-              }}
-            />
-          )}
-          {displayData?.includes('price') && <Info label='Price (month/year)' value={priceString} />}
-        </section>
+        {shows('argocd', 'grafana', 'rorcli') && (
+          <>
+            <section className={cn('grid gap-2', externalLinkNum(shows))}>
+              {shows('argocd') && <ExternalTool name='ArgoCD' url={argocdUrl} />}
+              {shows('grafana') && <ExternalTool name='Grafana' url={grafanaUrl} />}
+              {shows('rorcli') && (
+                <Button
+                  variant='rorcli'
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    copyToClipboard(rorLogin)
+                  }}
+                  className='font-bold'
+                >
+                  <Copy /> ROR CLI
+                </Button>
+              )}
+            </section>
+            <hr />
+          </>
+        )}
 
-        <hr />
+        {shows('agentVersion', 'kubernetesVersion', 'toolingVersion') && (
+          <section className={infoSectionCls}>
+            {shows('agentVersion') && <Info label='ROR agent version' value={rorAgentVersion} />}
+            {shows('kubernetesVersion') && <Info label='Kubernetes version' value={kubernetesVersion} />}
+            {shows('toolingVersion') && <Info label='NHN tooling version' value={nhnToolingVersion} />}
+          </section>
+        )}
 
-        <section className='flex flex-col gap-2'>
-          <Tools />
-          <CodeSnippetLogins />
-        </section>
+        {shows('serviceId') && (
+          <section className={infoSectionCls}>
+            <Info label='Service ID' value={serviceId} />
+          </section>
+        )}
 
-        <hr />
-
-        <section className='flex flex-col gap-1.5 [&>div]:grid [&>div]:grid-cols-2 [@container(max-width:360px)]:[&>div]:grid-cols-1'>
-          {displayData?.includes('agentVersion') && <Info label='ROR agent version' value={rorAgentVersion} />}
-          {displayData?.includes('kubernetesVersion') && <Info label='Kubernetes version' value={kubernetesVersion} />}
-          {displayData?.includes('toolingVersion') && <Info label='NHN tooling version' value={nhnToolingVersion} />}
-        </section>
-
-        <hr />
-
-        <div className='flex flex-col gap-1.5 [&>div]:grid [&>div]:grid-cols-2 [@container(max-width:360px)]:[&>div]:grid-cols-1'>
-          <Info label='Service ID' value={serviceId} />
-        </div>
-        <ServiceTags />
-
-        <hr />
-
-        <section className='flex flex-col gap-1.5 [&>div]:grid [&>div]:grid-cols-2 [@container(max-width:360px)]:[&>div]:grid-cols-1'>
-          <Info label='Region' value={`${region} (${country})`} />
-          <Info label='Availability zone' value={az} />
-          <Info label='Workspace' value={workspace} />
-        </section>
+        {shows('region', 'az') && (
+          <section className={infoSectionCls}>
+            {shows('region') && <Info label='Region' value={`${region} (${country})`} />}
+            {shows('az') && <Info label='Availability zone' value={az} />}
+          </section>
+        )}
       </CardContent>
     </Card>
   )

--- a/apps/web/src/features/cluster/components/cluster-card.tsx
+++ b/apps/web/src/features/cluster/components/cluster-card.tsx
@@ -78,10 +78,10 @@ interface ClusterCardProps {
 }
 
 function getPriceString(monthly: number | null | undefined, yearly: number | null | undefined): string {
-  const m = monthly ?? (yearly ? yearly / 12 : null)
-  const y = yearly ?? (monthly ? monthly * 12 : null)
+  const m = monthly ?? (yearly != null ? yearly / 12 : null)
+  const y = yearly ?? (monthly != null ? monthly * 12 : null)
 
-  if (!m && !y) return missingText
+  if (m == null && y == null) return missingText
   return `${m} kr / ${y} kr`
 }
 
@@ -317,7 +317,7 @@ const ClusterCard = ({ className, cluster, displayData }: ClusterCardProps) => {
                   variant='rorcli'
                   onClick={(e) => {
                     e.stopPropagation()
-                    copyToClipboard(rorLogin)
+                    void copyToClipboard(rorLogin).catch(() => {})
                   }}
                   className='font-bold'
                 >
@@ -330,17 +330,23 @@ const ClusterCard = ({ className, cluster, displayData }: ClusterCardProps) => {
         )}
 
         {shows('agentVersion', 'kubernetesVersion', 'toolingVersion') && (
-          <section className={infoSectionCls}>
-            {shows('agentVersion') && <Info label='ROR agent version' value={rorAgentVersion} />}
-            {shows('kubernetesVersion') && <Info label='Kubernetes version' value={kubernetesVersion} />}
-            {shows('toolingVersion') && <Info label='NHN tooling version' value={nhnToolingVersion} />}
-          </section>
+          <>
+            <section className={infoSectionCls}>
+              {shows('agentVersion') && <Info label='ROR agent version' value={rorAgentVersion} />}
+              {shows('kubernetesVersion') && <Info label='Kubernetes version' value={kubernetesVersion} />}
+              {shows('toolingVersion') && <Info label='NHN tooling version' value={nhnToolingVersion} />}
+            </section>
+            <hr />
+          </>
         )}
 
         {shows('serviceId') && (
-          <section className={infoSectionCls}>
-            <Info label='Service ID' value={serviceId} />
-          </section>
+          <>
+            <section className={infoSectionCls}>
+              <Info label='Service ID' value={serviceId} />
+            </section>
+            <hr />
+          </>
         )}
 
         {shows('region', 'az') && (

--- a/apps/web/src/features/cluster/components/clusters-columns.tsx
+++ b/apps/web/src/features/cluster/components/clusters-columns.tsx
@@ -46,7 +46,8 @@ const columnHelper = createColumnHelper<ClusterListViewRowType>()
 export function getClustersTableColumns(
   selectedDisplayData?: ClusterCardDisplayData[]
 ): DataTableColumnDef<ClusterListViewRowType>[] {
-  const isVisible = (id: ClusterCardDisplayData) => !selectedDisplayData || selectedDisplayData.includes(id)
+  const isVisible = (id: ClusterCardDisplayData) =>
+    !selectedDisplayData || selectedDisplayData.length === 0 || selectedDisplayData.includes(id)
 
   return [
     columnHelper.accessor(getClusterNameView, {

--- a/apps/web/src/features/cluster/components/clusters-columns.tsx
+++ b/apps/web/src/features/cluster/components/clusters-columns.tsx
@@ -24,6 +24,10 @@ import {
   getRorLoginView,
   getProviderView,
   getClusterUidView,
+  getServiceIdView,
+  getRegionView,
+  getCountryView,
+  getAZView,
 } from '../utils/cluster'
 import { Button } from '@/components/shadcn/button'
 
@@ -42,8 +46,7 @@ const columnHelper = createColumnHelper<ClusterListViewRowType>()
 export function getClustersTableColumns(
   selectedDisplayData?: ClusterCardDisplayData[]
 ): DataTableColumnDef<ClusterListViewRowType>[] {
-  const showAll = !selectedDisplayData || selectedDisplayData.length === 0
-  const isVisible = (id: ClusterCardDisplayData) => showAll || selectedDisplayData.includes(id)
+  const isVisible = (id: ClusterCardDisplayData) => !selectedDisplayData || selectedDisplayData.includes(id)
 
   return [
     columnHelper.accessor(getClusterNameView, {
@@ -350,6 +353,31 @@ export function getClustersTableColumns(
         },
         enableSorting: true,
         cell: (info) => <span>{info.getValue() || 'Unknown'}</span>,
+      }),
+    isVisible('serviceId') &&
+      columnHelper.accessor(getServiceIdView, {
+        id: 'serviceId',
+        size: 160,
+        header: () => <p className='text-sm'>Service ID</p>,
+        cell: (info) => <span>{info.getValue() || missingText}</span>,
+      }),
+    isVisible('region') &&
+      columnHelper.accessor(getRegionView, {
+        id: 'region',
+        size: 160,
+        header: () => <p className='text-sm'>Region</p>,
+        cell: (info) => {
+          const region = info.getValue()
+          const country = getCountryView(info.row.original)
+          return <span>{region && country ? `${region} (${country})` : region || missingText}</span>
+        },
+      }),
+    isVisible('az') &&
+      columnHelper.accessor(getAZView, {
+        id: 'az',
+        size: 160,
+        header: () => <p className='text-sm'>Availability zone</p>,
+        cell: (info) => <span>{info.getValue() || missingText}</span>,
       }),
   ].filter(Boolean) as DataTableColumnDef<ClusterListViewRowType>[]
 }

--- a/apps/web/src/features/cluster/config/page-view-options.ts
+++ b/apps/web/src/features/cluster/config/page-view-options.ts
@@ -25,7 +25,15 @@ export const displayDataOptions: Option[] = [
   { value: 'datacenterProvider', label: 'Datacenter provider' },
   { value: 'environment', label: 'Environment' },
   { value: 'serviceTags', label: 'Service tags' },
+  { value: 'serviceId', label: 'Service ID' },
+  { value: 'region', label: 'Region' },
+  { value: 'az', label: 'Availability zone' },
+  { value: 'workspace', label: 'Workspace' },
 ]
+
+const OPT_IN_FIELDS: string[] = ['agentVersion', 'kubernetesVersion', 'toolingVersion', 'serviceId', 'region', 'az']
+
+export const defaultDisplayData = displayDataOptions.map((o) => o.value).filter((v) => !OPT_IN_FIELDS.includes(v))
 
 /**
  * An array of sorting options for cluster page views.

--- a/apps/web/src/features/cluster/types/display-data.ts
+++ b/apps/web/src/features/cluster/types/display-data.ts
@@ -19,3 +19,7 @@ export type ClusterCardDisplayData =
   | 'datacenterProvider'
   | 'environment'
   | 'serviceTags'
+  | 'serviceId'
+  | 'region'
+  | 'az'
+  | 'workspace'


### PR DESCRIPTION
This PR aims to remove fields from the cluster card, as well as refactor the argocd, grafana and rorcli buttons. The user is still able to choose to see the removed fields. The code is also refactored to improve code quality.

This is the standard issue: 
<img width="1719" height="1091" alt="image" src="https://github.com/user-attachments/assets/47246da4-6ca2-4f85-937c-604c02b178f3" />
