### PR TITLE
Fix error in backup

### DIFF
--- a/apps/web/__mocks__/data/backup-run.ts
+++ b/apps/web/__mocks__/data/backup-run.ts
@@ -77,9 +77,9 @@ export const mockBackupRuns = {
               status: 'Failed',
             },
           ],
-          startTime: '2025-08-29T23:26:52Z',
-          endTime: '2025-08-29T23:30:09Z',
-          expiryTime: '2025-09-28T23:30:33Z',
+          startTime: '2026-08-29T23:26:52Z',
+          endTime: '2026-08-29T23:30:09Z',
+          expiryTime: '2026-09-28T23:30:33Z',
           backupStorage: {
             unit: 'bytes',
             sourceSize: 7472545792,

--- a/apps/web/src/app/(protected)/vms/[id]/backup/page.tsx
+++ b/apps/web/src/app/(protected)/vms/[id]/backup/page.tsx
@@ -3,13 +3,50 @@
 import { useVMContext } from '@/context/vm-context'
 import { BackupOverview } from '@/features/vms/backup/components'
 import type { VMWithBackupStatus } from '@/features/vms/backup/utils/map-backup-to-vm'
+import { useEffect, useState } from 'react'
+import type { BackupRun } from '@ror/js-api-client'
 
 export default function VMBackupPage() {
   const { vm } = useVMContext()
+  const [backupRuns, setBackupRuns] = useState<BackupRun[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
   const enhancedVM = vm as VMWithBackupStatus
   const hasBackupDataArrays = 'backupStatus' in enhancedVM && enhancedVM.backupStatus?.relatedBackupJobs !== undefined
   const relatedBackupJobs = enhancedVM.backupStatus?.relatedBackupJobs || []
-  const relatedBackupRuns = enhancedVM.backupStatus?.relatedBackupRuns || []
+  const relatedBackupRuns = backupRuns.length > 0 ? backupRuns : enhancedVM.backupStatus?.relatedBackupRuns || []
+
+  // Fetch backup runs for this VM's backup jobs on mount
+  useEffect(() => {
+    const fetchBackupRunsForVM = async () => {
+      try {
+        setIsLoading(true)
+        if (!relatedBackupJobs.length) {
+          setIsLoading(false)
+          return
+        }
+
+        const response = await fetch('/api/vm-backup-runs', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            backupJobs: relatedBackupJobs,
+          }),
+        })
+
+        if (response.ok) {
+          const data = await response.json()
+          setBackupRuns(data.backupRuns || [])
+        }
+      } catch (error) {
+        console.error('Error fetching backup runs:', error)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchBackupRunsForVM()
+  }, [relatedBackupJobs])
 
   return (
     <div className='space-y-6'>

--- a/apps/web/src/app/(protected)/vms/[id]/backup/page.tsx
+++ b/apps/web/src/app/(protected)/vms/[id]/backup/page.tsx
@@ -11,6 +11,8 @@ import { getVmExternalId } from '@/features/vms/utils/vms'
 export default function VMBackupPage() {
   const { vm } = useVMContext()
   const [backupRuns, setBackupRuns] = useState<BackupRun[]>([])
+  const [isBackupRunsLoading, setIsBackupRunsLoading] = useState(false)
+  const [hasFetchedBackupRuns, setHasFetchedBackupRuns] = useState(false)
 
   const enhancedVM = vm as VMWithBackupStatus
   const vmExternalId = getVmExternalId(enhancedVM)
@@ -21,11 +23,16 @@ export default function VMBackupPage() {
   // Fetch backup runs for this VM's backup jobs on mount
   useEffect(() => {
     const fetchBackupRunsForVM = async () => {
-      try {
-        if (!relatedBackupJobs.length) {
-          return
-        }
+      if (!relatedBackupJobs.length) {
+        setHasFetchedBackupRuns(true)
+        setIsBackupRunsLoading(false)
+        return
+      }
 
+      setIsBackupRunsLoading(true)
+      setHasFetchedBackupRuns(false)
+
+      try {
         const response = await fetch('/api/vm-backup-runs', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -49,6 +56,9 @@ export default function VMBackupPage() {
         }
       } catch (error) {
         console.error('Error fetching backup runs:', error)
+      } finally {
+        setIsBackupRunsLoading(false)
+        setHasFetchedBackupRuns(true)
       }
     }
 
@@ -58,7 +68,13 @@ export default function VMBackupPage() {
   return (
     <div className='space-y-6'>
       {hasBackupDataArrays ? (
-        <BackupOverview vm={enhancedVM} backupJobs={relatedBackupJobs} backupRuns={relatedBackupRuns} />
+        <BackupOverview
+          vm={enhancedVM}
+          backupJobs={relatedBackupJobs}
+          backupRuns={relatedBackupRuns}
+          isBackupRunsLoading={isBackupRunsLoading}
+          hasFetchedBackupRuns={hasFetchedBackupRuns}
+        />
       ) : (
         <div className='p-6 bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded-lg'>
           <div className='flex items-center space-x-3'>

--- a/apps/web/src/app/(protected)/vms/[id]/backup/page.tsx
+++ b/apps/web/src/app/(protected)/vms/[id]/backup/page.tsx
@@ -5,6 +5,8 @@ import { BackupOverview } from '@/features/vms/backup/components'
 import type { VMWithBackupStatus } from '@/features/vms/backup/utils/map-backup-to-vm'
 import { useEffect, useState } from 'react'
 import type { BackupRun } from '@ror/js-api-client'
+import { getBackupRunActiveTargets } from '@/features/vms/backup/utils/backup-run'
+import { getVmExternalId } from '@/features/vms/utils/vms'
 
 export default function VMBackupPage() {
   const { vm } = useVMContext()
@@ -12,6 +14,7 @@ export default function VMBackupPage() {
   const [isLoading, setIsLoading] = useState(true)
 
   const enhancedVM = vm as VMWithBackupStatus
+  const vmExternalId = getVmExternalId(enhancedVM)
   const hasBackupDataArrays = 'backupStatus' in enhancedVM && enhancedVM.backupStatus?.relatedBackupJobs !== undefined
   const relatedBackupJobs = enhancedVM.backupStatus?.relatedBackupJobs || []
   const relatedBackupRuns = backupRuns.length > 0 ? backupRuns : enhancedVM.backupStatus?.relatedBackupRuns || []
@@ -36,7 +39,16 @@ export default function VMBackupPage() {
 
         if (response.ok) {
           const data = await response.json()
-          setBackupRuns(data.backupRuns || [])
+          const fetchedRuns = (data.backupRuns || []) as BackupRun[]
+
+          const vmSpecificRuns = vmExternalId
+            ? fetchedRuns.filter((run) => {
+                const targets = getBackupRunActiveTargets(run)
+                return targets.some((target) => target.externalId === vmExternalId)
+              })
+            : fetchedRuns
+
+          setBackupRuns(vmSpecificRuns)
         }
       } catch (error) {
         console.error('Error fetching backup runs:', error)
@@ -46,7 +58,7 @@ export default function VMBackupPage() {
     }
 
     fetchBackupRunsForVM()
-  }, [relatedBackupJobs])
+  }, [relatedBackupJobs, vmExternalId])
 
   return (
     <div className='space-y-6'>

--- a/apps/web/src/app/(protected)/vms/[id]/backup/page.tsx
+++ b/apps/web/src/app/(protected)/vms/[id]/backup/page.tsx
@@ -3,7 +3,7 @@
 import { useVMContext } from '@/context/vm-context'
 import { BackupOverview } from '@/features/vms/backup/components'
 import type { VMWithBackupStatus } from '@/features/vms/backup/utils/map-backup-to-vm'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { BackupRun } from '@ror/js-api-client'
 import { getBackupRunActiveTargets } from '@/features/vms/backup/utils/backup-run'
 import { getVmExternalId } from '@/features/vms/utils/vms'
@@ -11,21 +11,18 @@ import { getVmExternalId } from '@/features/vms/utils/vms'
 export default function VMBackupPage() {
   const { vm } = useVMContext()
   const [backupRuns, setBackupRuns] = useState<BackupRun[]>([])
-  const [isLoading, setIsLoading] = useState(true)
 
   const enhancedVM = vm as VMWithBackupStatus
   const vmExternalId = getVmExternalId(enhancedVM)
   const hasBackupDataArrays = 'backupStatus' in enhancedVM && enhancedVM.backupStatus?.relatedBackupJobs !== undefined
-  const relatedBackupJobs = enhancedVM.backupStatus?.relatedBackupJobs || []
+  const relatedBackupJobs = useMemo(() => enhancedVM.backupStatus?.relatedBackupJobs || [], [enhancedVM])
   const relatedBackupRuns = backupRuns.length > 0 ? backupRuns : enhancedVM.backupStatus?.relatedBackupRuns || []
 
   // Fetch backup runs for this VM's backup jobs on mount
   useEffect(() => {
     const fetchBackupRunsForVM = async () => {
       try {
-        setIsLoading(true)
         if (!relatedBackupJobs.length) {
-          setIsLoading(false)
           return
         }
 
@@ -52,8 +49,6 @@ export default function VMBackupPage() {
         }
       } catch (error) {
         console.error('Error fetching backup runs:', error)
-      } finally {
-        setIsLoading(false)
       }
     }
 

--- a/apps/web/src/app/(protected)/vms/page-view.tsx
+++ b/apps/web/src/app/(protected)/vms/page-view.tsx
@@ -38,12 +38,11 @@ import {
   getSpecMemory,
   getSpecCpuTotal,
   getLocation,
-  getVmExternalId,
 } from '@/features/vms/utils/vms'
 import { NotReadyMessage } from '@/components/ui/not-ready-message'
 import { cn } from '@/utils/clsxm'
 import { SearchX } from 'lucide-react'
-import { useMemo, useCallback, useState, useEffect, useRef } from 'react'
+import { useMemo, useCallback, useState } from 'react'
 import { VMCard } from '@/features/vms/components/vm-card'
 import { VMCardData } from '@/features/vms/types/vm-types'
 import { displayDataOptions, sortingOptions } from '@/features/vms/config/page-view-options'
@@ -56,22 +55,14 @@ import { useFilters } from '@/hooks/use-filters'
 import { SortDefinition, useSorting } from '@/hooks/use-sorting'
 import { DataTable } from '@/components/ui/data-table'
 import { getVMTableColumns } from '@/features/vms/components/vm-columns'
-import {
-  getBackupRunActiveTargets,
-  getBackupRunInfo,
-  type LastBackupInfo,
-} from '@/features/vms/backup/utils/backup-run'
-import type { BackupRun, VirtualMachine } from '@ror/js-api-client'
+import { type LastBackupInfo } from '@/features/vms/backup/utils/backup-run'
+import type { VirtualMachine } from '@ror/js-api-client'
 import type { VMWithBackupStatus } from '@/features/vms/backup/utils/map-backup-to-vm'
 import { useInfiniteLoader } from '@/hooks/use-infinite-loader'
 import { loadMoreVMs } from '@/utils/vms-actions'
 import { VmFilterSection } from '@/features/vms/components/vm-filter-section'
 import { getSpecificLocation } from '@/features/vms/hooks/use-vm-search'
-
-const VM_BACKUP_INFO_CACHE_KEY = 'vm-last-backup-info-v1'
-const VM_BACKUP_INFO_CACHE_TTL_MS = 6 * 60 * 60 * 1000
-const VM_BACKUP_RUN_BATCH_SIZE = 200
-const RUN_IDS_PER_JOB = 3
+import { useBackupInfoHydration } from '@/features/vms/backup/services/backup-cache'
 
 const isExpiredBackup = (expiryTime?: string | null) => {
   if (!expiryTime) return false
@@ -79,17 +70,9 @@ const isExpiredBackup = (expiryTime?: string | null) => {
   if (Number.isNaN(expiryDate.getTime())) return false
   return expiryDate.getTime() < Date.now()
 }
-
-type BackupInfoCacheEntry = LastBackupInfo & { cachedAt: number }
-type BackupInfoCacheMap = Record<string, BackupInfoCacheEntry>
-
 export const PageView = ({ className, vms, params }: PageViewProps) => {
   const filtersOpen = params.filterPanel === 'open'
   const [searchResetKey, setSearchResetKey] = useState(0)
-  const [hydratedBackupInfoByVmId, setHydratedBackupInfoByVmId] = useState<BackupInfoCacheMap>({})
-  const requestedRunIdsRef = useRef<Set<string>>(new Set())
-  const hydrateInFlightRef = useRef(false)
-
   const { items, sentinelRef, isLoading, hasMore } = useInfiniteLoader<VirtualMachine | VMWithBackupStatus>({
     initial: vms,
     sort: params.sort,
@@ -108,177 +91,7 @@ export const PageView = ({ className, vms, params }: PageViewProps) => {
       return { items: res.items ?? [], hasMore: res.hasMore }
     },
   })
-
-  useEffect(() => {
-    try {
-      const raw = localStorage.getItem(VM_BACKUP_INFO_CACHE_KEY)
-      if (!raw) return
-
-      const parsed = JSON.parse(raw) as BackupInfoCacheMap
-      const now = Date.now()
-      const next: BackupInfoCacheMap = {}
-
-      for (const [vmExternalId, entry] of Object.entries(parsed)) {
-        if (entry?.cachedAt && now - entry.cachedAt < VM_BACKUP_INFO_CACHE_TTL_MS) {
-          next[vmExternalId] = entry
-        }
-      }
-
-      setHydratedBackupInfoByVmId(next)
-    } catch {
-      // Ignore invalid cache payload.
-    }
-  }, [])
-
-  const hydratedItems = useMemo(() => {
-    return items.map((item) => {
-      if (!('backupStatus' in item)) {
-        return item
-      }
-
-      if (item.backupStatus?.lastBackupInfo) {
-        return item
-      }
-
-      const vmExternalId = getVmExternalId(item)
-      if (!vmExternalId) {
-        return item
-      }
-
-      const cached = hydratedBackupInfoByVmId[vmExternalId]
-      if (!cached) {
-        return item
-      }
-
-      return {
-        ...item,
-        backupStatus: {
-          ...item.backupStatus,
-          lastBackupInfo: {
-            startTime: cached.startTime,
-            endTime: cached.endTime,
-            expiryTime: cached.expiryTime,
-          },
-        },
-      }
-    })
-  }, [items, hydratedBackupInfoByVmId])
-
-  useEffect(() => {
-    if (hydrateInFlightRef.current) return
-
-    const vmCandidateRunIds = new Map<string, Set<string>>()
-    const candidateRunIds: string[] = []
-    const seenCandidateRunIds = new Set<string>()
-
-    for (const item of items) {
-      if (!('backupStatus' in item)) continue
-
-      const backupStatus = item.backupStatus
-      if (!backupStatus?.hasBackupRun || backupStatus.lastBackupInfo) continue
-
-      const vmExternalId = getVmExternalId(item)
-      if (!vmExternalId || hydratedBackupInfoByVmId[vmExternalId]) continue
-
-      const runIdSet = new Set<string>()
-
-      for (const job of backupStatus.relatedBackupJobs ?? []) {
-        const runIds = job?.backupjob?.status?.backupRunIds ?? []
-        for (const runId of runIds.slice(0, RUN_IDS_PER_JOB)) {
-          if (!runId) continue
-          runIdSet.add(runId)
-        }
-      }
-
-      if (!runIdSet.size) continue
-
-      vmCandidateRunIds.set(vmExternalId, runIdSet)
-
-      for (const runId of runIdSet) {
-        if (requestedRunIdsRef.current.has(runId) || seenCandidateRunIds.has(runId)) continue
-        seenCandidateRunIds.add(runId)
-        candidateRunIds.push(runId)
-      }
-    }
-
-    if (!candidateRunIds.length || !vmCandidateRunIds.size) return
-
-    const runIdsBatch = candidateRunIds.slice(0, VM_BACKUP_RUN_BATCH_SIZE)
-    for (const runId of runIdsBatch) {
-      requestedRunIdsRef.current.add(runId)
-    }
-
-    hydrateInFlightRef.current = true
-
-    void (async () => {
-      try {
-        const response = await fetch('/api/vm-backup-runs', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ runIds: runIdsBatch }),
-        })
-
-        if (!response.ok) return
-
-        const payload = (await response.json()) as { backupRuns?: BackupRun[] }
-        const fetchedRuns = payload.backupRuns ?? []
-        if (!fetchedRuns.length) return
-
-        const now = Date.now()
-        const updates: BackupInfoCacheMap = {}
-
-        for (const [vmExternalId, runIdSet] of vmCandidateRunIds.entries()) {
-          let latestBackupInfo: LastBackupInfo | null = null
-          let latestTs = 0
-
-          for (const run of fetchedRuns) {
-            const runId = run?.backuprun?.id
-            if (!runId || !runIdSet.has(runId)) continue
-
-            const targets = getBackupRunActiveTargets(run)
-            const targetsVm = targets.some((target) => target.externalId === vmExternalId)
-            if (!targetsVm) continue
-
-            const info = getBackupRunInfo(run)
-            if (!info.startTime) continue
-
-            const ts = Date.parse(info.startTime)
-            if (!Number.isFinite(ts) || ts < latestTs) continue
-
-            latestTs = ts
-            latestBackupInfo = {
-              startTime: info.startTime,
-              endTime: info.endTime,
-              expiryTime: info.expiryTime,
-            }
-          }
-
-          if (latestBackupInfo) {
-            updates[vmExternalId] = {
-              ...latestBackupInfo,
-              cachedAt: now,
-            }
-          }
-        }
-
-        if (!Object.keys(updates).length) return
-
-        setHydratedBackupInfoByVmId((prev) => {
-          const next = { ...prev, ...updates }
-          try {
-            localStorage.setItem(VM_BACKUP_INFO_CACHE_KEY, JSON.stringify(next))
-          } catch {
-            // Ignore storage quota/write errors.
-          }
-          return next
-        })
-      } catch {
-        // Keep page resilient if hydration fetch fails.
-      } finally {
-        hydrateInFlightRef.current = false
-      }
-    })()
-  }, [items, hydratedBackupInfoByVmId])
+  const hydratedItems = useBackupInfoHydration(items)
 
   const safeItems = useMemo(
     () => hydratedItems.filter((c) => getVmOperatingSystem(c) && typeof getVmOperatingSystem(c) === 'object'),

--- a/apps/web/src/app/(protected)/vms/page-view.tsx
+++ b/apps/web/src/app/(protected)/vms/page-view.tsx
@@ -73,6 +73,13 @@ const VM_BACKUP_INFO_CACHE_TTL_MS = 6 * 60 * 60 * 1000
 const VM_BACKUP_RUN_BATCH_SIZE = 200
 const RUN_IDS_PER_JOB = 3
 
+const isExpiredBackup = (expiryTime?: string | null) => {
+  if (!expiryTime) return false
+  const expiryDate = new Date(expiryTime)
+  if (Number.isNaN(expiryDate.getTime())) return false
+  return expiryDate.getTime() < Date.now()
+}
+
 type BackupInfoCacheEntry = LastBackupInfo & { cachedAt: number }
 type BackupInfoCacheMap = Record<string, BackupInfoCacheEntry>
 
@@ -292,7 +299,14 @@ export const PageView = ({ className, vms, params }: PageViewProps) => {
       key: 'Backup',
       extractor: (vm: VirtualMachine | VMWithBackupStatus) => {
         if ('backupStatus' in vm) {
-          const backupStatus = vm.backupStatus as { hasBackupJob: boolean; hasBackupRun: boolean }
+          const backupStatus = vm.backupStatus as {
+            hasBackupJob: boolean
+            hasBackupRun: boolean
+            lastBackupInfo?: LastBackupInfo | null
+          }
+          const isExpired = backupStatus.hasBackupRun && isExpiredBackup(backupStatus.lastBackupInfo?.expiryTime)
+
+          if (isExpired) return 'expiredBackup'
           if (backupStatus.hasBackupJob && backupStatus.hasBackupRun) return 'activeBackup'
           if (backupStatus.hasBackupRun) return 'historicalBackup'
           if (backupStatus.hasBackupJob) return 'configuredBackup'
@@ -319,24 +333,38 @@ export const PageView = ({ className, vms, params }: PageViewProps) => {
       key: 'activeBackup',
       extractor: (vm) => {
         if ('backupStatus' in vm) {
-          const backupStatus = vm.backupStatus as { hasBackupJob: boolean; hasBackupRun: boolean }
+          const backupStatus = vm.backupStatus as {
+            hasBackupJob: boolean
+            hasBackupRun: boolean
+            lastBackupInfo?: LastBackupInfo | null
+          }
+          const isExpired = backupStatus.hasBackupRun && isExpiredBackup(backupStatus.lastBackupInfo?.expiryTime)
+
+          if (isExpired) return 2 // Expired backup
           if (backupStatus.hasBackupJob && backupStatus.hasBackupRun) return 1 // Active backup
-          if (backupStatus.hasBackupRun) return 2 // Historical backup
-          if (backupStatus.hasBackupJob) return 3 // Configured backup
-          return 4 // No backup
+          if (backupStatus.hasBackupRun) return 3 // Historical backup
+          if (backupStatus.hasBackupJob) return 4 // Configured backup
+          return 5 // No backup
         }
-        return 4 // No backup data
+        return 5 // No backup data
       },
       compareFn: (a, b) => {
         const getBackupPriority = (vm: VirtualMachine | VMWithBackupStatus) => {
           if ('backupStatus' in vm) {
-            const backupStatus = vm.backupStatus as { hasBackupJob: boolean; hasBackupRun: boolean }
+            const backupStatus = vm.backupStatus as {
+              hasBackupJob: boolean
+              hasBackupRun: boolean
+              lastBackupInfo?: LastBackupInfo | null
+            }
+            const isExpired = backupStatus.hasBackupRun && isExpiredBackup(backupStatus.lastBackupInfo?.expiryTime)
+
+            if (isExpired) return 2 // Expired backup
             if (backupStatus.hasBackupJob && backupStatus.hasBackupRun) return 1 // Active backup (highest priority)
-            if (backupStatus.hasBackupRun) return 2 // Historical backup
-            if (backupStatus.hasBackupJob) return 3 // Configured backup
-            return 4 // No backup
+            if (backupStatus.hasBackupRun) return 3 // Historical backup
+            if (backupStatus.hasBackupJob) return 4 // Configured backup
+            return 5 // No backup
           }
-          return 4 // No backup data
+          return 5 // No backup data
         }
 
         return getBackupPriority(a) - getBackupPriority(b)

--- a/apps/web/src/app/(protected)/vms/page-view.tsx
+++ b/apps/web/src/app/(protected)/vms/page-view.tsx
@@ -38,11 +38,12 @@ import {
   getSpecMemory,
   getSpecCpuTotal,
   getLocation,
+  getVmExternalId,
 } from '@/features/vms/utils/vms'
 import { NotReadyMessage } from '@/components/ui/not-ready-message'
 import { cn } from '@/utils/clsxm'
 import { SearchX } from 'lucide-react'
-import { useMemo, useCallback, useState } from 'react'
+import { useMemo, useCallback, useState, useEffect, useRef } from 'react'
 import { VMCard } from '@/features/vms/components/vm-card'
 import { VMCardData } from '@/features/vms/types/vm-types'
 import { displayDataOptions, sortingOptions } from '@/features/vms/config/page-view-options'
@@ -55,16 +56,32 @@ import { useFilters } from '@/hooks/use-filters'
 import { SortDefinition, useSorting } from '@/hooks/use-sorting'
 import { DataTable } from '@/components/ui/data-table'
 import { getVMTableColumns } from '@/features/vms/components/vm-columns'
-import type { VirtualMachine } from '@ror/js-api-client'
+import {
+  getBackupRunActiveTargets,
+  getBackupRunInfo,
+  type LastBackupInfo,
+} from '@/features/vms/backup/utils/backup-run'
+import type { BackupRun, VirtualMachine } from '@ror/js-api-client'
 import type { VMWithBackupStatus } from '@/features/vms/backup/utils/map-backup-to-vm'
 import { useInfiniteLoader } from '@/hooks/use-infinite-loader'
 import { loadMoreVMs } from '@/utils/vms-actions'
 import { VmFilterSection } from '@/features/vms/components/vm-filter-section'
 import { getSpecificLocation } from '@/features/vms/hooks/use-vm-search'
 
+const VM_BACKUP_INFO_CACHE_KEY = 'vm-last-backup-info-v1'
+const VM_BACKUP_INFO_CACHE_TTL_MS = 6 * 60 * 60 * 1000
+const VM_BACKUP_RUN_BATCH_SIZE = 200
+const RUN_IDS_PER_JOB = 3
+
+type BackupInfoCacheEntry = LastBackupInfo & { cachedAt: number }
+type BackupInfoCacheMap = Record<string, BackupInfoCacheEntry>
+
 export const PageView = ({ className, vms, params }: PageViewProps) => {
   const filtersOpen = params.filterPanel === 'open'
   const [searchResetKey, setSearchResetKey] = useState(0)
+  const [hydratedBackupInfoByVmId, setHydratedBackupInfoByVmId] = useState<BackupInfoCacheMap>({})
+  const requestedRunIdsRef = useRef<Set<string>>(new Set())
+  const hydrateInFlightRef = useRef(false)
 
   const { items, sentinelRef, isLoading, hasMore } = useInfiniteLoader<VirtualMachine | VMWithBackupStatus>({
     initial: vms,
@@ -85,9 +102,180 @@ export const PageView = ({ className, vms, params }: PageViewProps) => {
     },
   })
 
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(VM_BACKUP_INFO_CACHE_KEY)
+      if (!raw) return
+
+      const parsed = JSON.parse(raw) as BackupInfoCacheMap
+      const now = Date.now()
+      const next: BackupInfoCacheMap = {}
+
+      for (const [vmExternalId, entry] of Object.entries(parsed)) {
+        if (entry?.cachedAt && now - entry.cachedAt < VM_BACKUP_INFO_CACHE_TTL_MS) {
+          next[vmExternalId] = entry
+        }
+      }
+
+      setHydratedBackupInfoByVmId(next)
+    } catch {
+      // Ignore invalid cache payload.
+    }
+  }, [])
+
+  const hydratedItems = useMemo(() => {
+    return items.map((item) => {
+      if (!('backupStatus' in item)) {
+        return item
+      }
+
+      if (item.backupStatus?.lastBackupInfo) {
+        return item
+      }
+
+      const vmExternalId = getVmExternalId(item)
+      if (!vmExternalId) {
+        return item
+      }
+
+      const cached = hydratedBackupInfoByVmId[vmExternalId]
+      if (!cached) {
+        return item
+      }
+
+      return {
+        ...item,
+        backupStatus: {
+          ...item.backupStatus,
+          lastBackupInfo: {
+            startTime: cached.startTime,
+            endTime: cached.endTime,
+            expiryTime: cached.expiryTime,
+          },
+        },
+      }
+    })
+  }, [items, hydratedBackupInfoByVmId])
+
+  useEffect(() => {
+    if (hydrateInFlightRef.current) return
+
+    const vmCandidateRunIds = new Map<string, Set<string>>()
+    const candidateRunIds: string[] = []
+    const seenCandidateRunIds = new Set<string>()
+
+    for (const item of items) {
+      if (!('backupStatus' in item)) continue
+
+      const backupStatus = item.backupStatus
+      if (!backupStatus?.hasBackupRun || backupStatus.lastBackupInfo) continue
+
+      const vmExternalId = getVmExternalId(item)
+      if (!vmExternalId || hydratedBackupInfoByVmId[vmExternalId]) continue
+
+      const runIdSet = new Set<string>()
+
+      for (const job of backupStatus.relatedBackupJobs ?? []) {
+        const runIds = job?.backupjob?.status?.backupRunIds ?? []
+        for (const runId of runIds.slice(0, RUN_IDS_PER_JOB)) {
+          if (!runId) continue
+          runIdSet.add(runId)
+        }
+      }
+
+      if (!runIdSet.size) continue
+
+      vmCandidateRunIds.set(vmExternalId, runIdSet)
+
+      for (const runId of runIdSet) {
+        if (requestedRunIdsRef.current.has(runId) || seenCandidateRunIds.has(runId)) continue
+        seenCandidateRunIds.add(runId)
+        candidateRunIds.push(runId)
+      }
+    }
+
+    if (!candidateRunIds.length || !vmCandidateRunIds.size) return
+
+    const runIdsBatch = candidateRunIds.slice(0, VM_BACKUP_RUN_BATCH_SIZE)
+    for (const runId of runIdsBatch) {
+      requestedRunIdsRef.current.add(runId)
+    }
+
+    hydrateInFlightRef.current = true
+
+    void (async () => {
+      try {
+        const response = await fetch('/api/vm-backup-runs', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ runIds: runIdsBatch }),
+        })
+
+        if (!response.ok) return
+
+        const payload = (await response.json()) as { backupRuns?: BackupRun[] }
+        const fetchedRuns = payload.backupRuns ?? []
+        if (!fetchedRuns.length) return
+
+        const now = Date.now()
+        const updates: BackupInfoCacheMap = {}
+
+        for (const [vmExternalId, runIdSet] of vmCandidateRunIds.entries()) {
+          let latestBackupInfo: LastBackupInfo | null = null
+          let latestTs = 0
+
+          for (const run of fetchedRuns) {
+            const runId = run?.backuprun?.id
+            if (!runId || !runIdSet.has(runId)) continue
+
+            const targets = getBackupRunActiveTargets(run)
+            const targetsVm = targets.some((target) => target.externalId === vmExternalId)
+            if (!targetsVm) continue
+
+            const info = getBackupRunInfo(run)
+            if (!info.startTime) continue
+
+            const ts = Date.parse(info.startTime)
+            if (!Number.isFinite(ts) || ts < latestTs) continue
+
+            latestTs = ts
+            latestBackupInfo = {
+              startTime: info.startTime,
+              endTime: info.endTime,
+              expiryTime: info.expiryTime,
+            }
+          }
+
+          if (latestBackupInfo) {
+            updates[vmExternalId] = {
+              ...latestBackupInfo,
+              cachedAt: now,
+            }
+          }
+        }
+
+        if (!Object.keys(updates).length) return
+
+        setHydratedBackupInfoByVmId((prev) => {
+          const next = { ...prev, ...updates }
+          try {
+            localStorage.setItem(VM_BACKUP_INFO_CACHE_KEY, JSON.stringify(next))
+          } catch {
+            // Ignore storage quota/write errors.
+          }
+          return next
+        })
+      } catch {
+        // Keep page resilient if hydration fetch fails.
+      } finally {
+        hydrateInFlightRef.current = false
+      }
+    })()
+  }, [items, hydratedBackupInfoByVmId])
+
   const safeItems = useMemo(
-    () => items.filter((c) => getVmOperatingSystem(c) && typeof getVmOperatingSystem(c) === 'object'),
-    [items]
+    () => hydratedItems.filter((c) => getVmOperatingSystem(c) && typeof getVmOperatingSystem(c) === 'object'),
+    [hydratedItems]
   )
 
   const filterDefinitions = [
@@ -240,7 +428,7 @@ export const PageView = ({ className, vms, params }: PageViewProps) => {
         getItemsKey={getVmsKey}
         exportAsCSV={exportVmsAsCSV}
         exportAsExcel={exportVmsAsExcel}
-        allItems={items}
+        allItems={hydratedItems}
         filteredItems={filteredItems}
       />
     </div>

--- a/apps/web/src/app/(protected)/vms/page.tsx
+++ b/apps/web/src/app/(protected)/vms/page.tsx
@@ -12,6 +12,7 @@ import { normalizeParams } from '@/features/vms/utils/normalize-params'
 import { fetchVms } from '@/features/vms/services/fetch-vms'
 import { fetchBackupJobs } from '@/features/vms/backup/services/fetch-backupJobs'
 import { fetchBackupRuns } from '@/features/vms/backup/services/fetch-backupRuns'
+import { fetchBackupRunsForJobs } from '@/features/vms/backup/services/fetch-backupRuns-for-jobs'
 import { mapBackupToVM } from '@/features/vms/backup/utils/map-backup-to-vm'
 import { getRorApi } from '@/services/ror-api'
 import type { Metadata } from 'next'
@@ -41,7 +42,21 @@ export default async function VMPage({
 
   const vms = fetchedVms.vms
   const backupJobs = fetchedBackupJobs.backupJobs || []
-  const backupRuns = fetchedBackupRuns.backupRuns || []
+  let backupRuns = [...(fetchedBackupRuns.backupRuns || [])]
+
+  // Supplement with backup runs referenced by the discovered jobs
+  try {
+    const jobSpecificRuns = await fetchBackupRunsForJobs(api, backupJobs).catch(() => [])
+    const runIdSet = new Set(backupRuns.map((r) => r?.backuprun?.id))
+    for (const run of jobSpecificRuns) {
+      const runId = run?.backuprun?.id
+      if (runId && !runIdSet.has(runId)) {
+        backupRuns.push(run)
+      }
+    }
+  } catch (error) {
+    console.error('Error fetching job-specific backup runs:', error)
+  }
 
   const vmsWithBackup = mapBackupToVM(vms, backupJobs, backupRuns)
 

--- a/apps/web/src/app/(protected)/vms/page.tsx
+++ b/apps/web/src/app/(protected)/vms/page.tsx
@@ -42,22 +42,27 @@ export default async function VMPage({
 
   const vms = fetchedVms.vms
   const backupJobs = fetchedBackupJobs.backupJobs || []
-  let backupRuns = [...(fetchedBackupRuns.backupRuns || [])]
+  const initialBackupRuns = [...(fetchedBackupRuns.backupRuns || [])]
+  let mergedBackupRuns = initialBackupRuns
 
   try {
     const jobSpecificRuns = await fetchBackupRunsForJobs(api, backupJobs).catch(() => [])
-    const runIdSet = new Set(backupRuns.map((r) => r?.backuprun?.id))
+    const runIdSet = new Set(initialBackupRuns.map((r) => r?.backuprun?.id))
+    const extraRuns = []
+
     for (const run of jobSpecificRuns) {
       const runId = run?.backuprun?.id
       if (runId && !runIdSet.has(runId)) {
-        backupRuns.push(run)
+        extraRuns.push(run)
       }
     }
+
+    mergedBackupRuns = [...initialBackupRuns, ...extraRuns]
   } catch (error) {
     console.error('Error fetching job-specific backup runs:', error)
   }
 
-  const vmsWithBackup = mapBackupToVM(vms, backupJobs, backupRuns)
+  const vmsWithBackup = mapBackupToVM(vms, backupJobs, mergedBackupRuns)
 
   return (
     <div className='w-full flex flex-col'>

--- a/apps/web/src/app/(protected)/vms/page.tsx
+++ b/apps/web/src/app/(protected)/vms/page.tsx
@@ -36,7 +36,7 @@ export default async function VMPage({
   const [fetchedVms, fetchedBackupJobs, fetchedBackupRuns] = await Promise.all([
     fetchVms(api, params),
     fetchBackupJobs(api, params).catch(() => ({ backupJobs: [] })),
-    fetchBackupRuns(api, params).catch(() => ({ backupRuns: [] })),
+    fetchBackupRuns(api, { page: 1, limit: 500, order: 'desc' }).catch(() => ({ backupRuns: [] })),
   ])
 
   const vms = fetchedVms.vms

--- a/apps/web/src/app/(protected)/vms/page.tsx
+++ b/apps/web/src/app/(protected)/vms/page.tsx
@@ -44,7 +44,6 @@ export default async function VMPage({
   const backupJobs = fetchedBackupJobs.backupJobs || []
   let backupRuns = [...(fetchedBackupRuns.backupRuns || [])]
 
-  // Supplement with backup runs referenced by the discovered jobs
   try {
     const jobSpecificRuns = await fetchBackupRunsForJobs(api, backupJobs).catch(() => [])
     const runIdSet = new Set(backupRuns.map((r) => r?.backuprun?.id))

--- a/apps/web/src/app/api/vm-backup-runs/route.ts
+++ b/apps/web/src/app/api/vm-backup-runs/route.ts
@@ -1,17 +1,21 @@
 import { getRorApi } from '@/services/ror-api'
-import { fetchBackupRunsForJobs } from '@/features/vms/backup/services/fetch-backupRuns-for-jobs'
-import type { BackupJob } from '@ror/js-api-client'
+import { fetchBackupRunsByIds, fetchBackupRunsForJobs } from '@/features/vms/backup/services/fetch-backupRuns-for-jobs'
 
 export async function POST(request: Request) {
   try {
-    const { backupJobs } = await request.json()
+    const { backupJobs, runIds } = await request.json()
 
-    if (!backupJobs || !Array.isArray(backupJobs)) {
+    const hasBackupJobs = Array.isArray(backupJobs)
+    const hasRunIds = Array.isArray(runIds)
+
+    if (!hasBackupJobs && !hasRunIds) {
       return Response.json({ backupRuns: [] }, { status: 400 })
     }
 
     const api = await getRorApi()
-    const backupRuns = await fetchBackupRunsForJobs(api, backupJobs)
+    const backupRuns = hasRunIds
+      ? await fetchBackupRunsByIds(api, runIds)
+      : await fetchBackupRunsForJobs(api, backupJobs)
 
     return Response.json({ backupRuns })
   } catch (error) {

--- a/apps/web/src/app/api/vm-backup-runs/route.ts
+++ b/apps/web/src/app/api/vm-backup-runs/route.ts
@@ -1,0 +1,21 @@
+import { getRorApi } from '@/services/ror-api'
+import { fetchBackupRunsForJobs } from '@/features/vms/backup/services/fetch-backupRuns-for-jobs'
+import type { BackupJob } from '@ror/js-api-client'
+
+export async function POST(request: Request) {
+  try {
+    const { backupJobs } = await request.json()
+
+    if (!backupJobs || !Array.isArray(backupJobs)) {
+      return Response.json({ backupRuns: [] }, { status: 400 })
+    }
+
+    const api = await getRorApi()
+    const backupRuns = await fetchBackupRunsForJobs(api, backupJobs)
+
+    return Response.json({ backupRuns })
+  } catch (error) {
+    console.error('Error in backup runs API route:', error)
+    return Response.json({ backupRuns: [], error: String(error) }, { status: 500 })
+  }
+}

--- a/apps/web/src/app/api/vm-backup-runs/route.ts
+++ b/apps/web/src/app/api/vm-backup-runs/route.ts
@@ -1,7 +1,9 @@
 import { getRorApi } from '@/services/ror-api'
 import { fetchBackupRunsByIds, fetchBackupRunsForJobs } from '@/features/vms/backup/services/fetch-backupRuns-for-jobs'
+import { authGuard } from '@/features/auth/utils/auth-guard'
 
 export async function POST(request: Request) {
+  await authGuard()
   try {
     const { backupJobs, runIds } = await request.json()
 

--- a/apps/web/src/features/vms/backup/components/backup-overview.tsx
+++ b/apps/web/src/features/vms/backup/components/backup-overview.tsx
@@ -34,8 +34,11 @@ interface BackupOverviewProps {
   backupRuns: BackupRun[]
 }
 
-const formatDateTime = (dateString: string) => {
-  return format(new Date(dateString), "MMM dd, yyyy 'at' HH:mm")
+const formatDateTime = (dateString: string | null | undefined) => {
+  if (!dateString) return 'N/A'
+  const date = new Date(dateString)
+  if (isNaN(date.getTime())) return 'N/A'
+  return format(date, "MMM dd, yyyy 'at' HH:mm")
 }
 
 const formatBytes = (bytes: number) => {
@@ -72,9 +75,17 @@ const getStatusColor = (status: string) => {
   }
 }
 
-const getBackupStatusColor = (isActive: boolean, hasRuns: boolean, hasActiveJobs: boolean, latestStatus: string) => {
+const getBackupStatusColor = (
+  isActive: boolean,
+  isExpired: boolean,
+  hasRuns: boolean,
+  hasActiveJobs: boolean,
+  latestStatus: string
+) => {
   if (isActive) {
     return getStatusColor(latestStatus)
+  } else if (isExpired) {
+    return 'bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-300'
   } else if (hasRuns) {
     return 'bg-amber-100 text-amber-800 dark:bg-amber-900/20 dark:text-amber-300'
   } else if (hasActiveJobs) {
@@ -390,18 +401,31 @@ export const BackupOverview: React.FC<BackupOverviewProps> = ({ backupJobs, back
     })
   }, [backupRuns])
 
+  const isRunExpired = (run: BackupRun) => {
+    const expiry = getBackupRunExpiryTime(run)
+    if (!expiry || expiry === 'No expiry time') return false
+    const expiryDate = new Date(expiry)
+    if (Number.isNaN(expiryDate.getTime())) return false
+    return expiryDate.getTime() < Date.now()
+  }
+
   const backupSummary = React.useMemo(() => {
     const hasActiveJob = backupJobs.length > 0
     const hasRuns = backupRuns.length > 0
+    const hasNonExpiredRuns = backupRuns.some((run) => !isRunExpired(run))
+    const hasExpiredRuns = backupRuns.some((run) => isRunExpired(run))
     const latestRunInfo = latestRun ? getBackupRunInfo(latestRun) : null
 
     return {
       hasActiveJob,
       hasRuns,
+      hasNonExpiredRuns,
+      hasExpiredRuns,
       totalJobs: backupJobs.length,
       totalRuns: backupRuns.length,
       latestStatus: latestRunInfo?.backupDestinations?.[0]?.status || 'Unknown',
-      isActive: hasActiveJob && hasRuns,
+      isActive: hasActiveJob && hasNonExpiredRuns,
+      isExpired: hasExpiredRuns && !hasNonExpiredRuns,
     }
   }, [backupJobs, backupRuns, latestRun])
 
@@ -419,6 +443,8 @@ export const BackupOverview: React.FC<BackupOverviewProps> = ({ backupJobs, back
           <div className='flex items-center space-x-2'>
             {backupSummary.isActive ? (
               getStatusIcon(backupSummary.latestStatus)
+            ) : backupSummary.isExpired ? (
+              <AlertTriangle className='w-4 h-4 text-red-500' />
             ) : backupSummary.hasRuns ? (
               <AlertTriangle className='w-4 h-4 text-amber-500' />
             ) : backupSummary.hasActiveJob ? (
@@ -429,6 +455,7 @@ export const BackupOverview: React.FC<BackupOverviewProps> = ({ backupJobs, back
             <Badge
               className={getBackupStatusColor(
                 backupSummary.isActive,
+                backupSummary.isExpired,
                 backupSummary.hasRuns,
                 backupSummary.hasActiveJob,
                 backupSummary.latestStatus
@@ -436,11 +463,13 @@ export const BackupOverview: React.FC<BackupOverviewProps> = ({ backupJobs, back
             >
               {backupSummary.isActive
                 ? 'Active'
-                : backupSummary.hasRuns
-                  ? 'Historical'
-                  : backupSummary.hasActiveJob
-                    ? 'Configured backup'
-                    : 'No Backups'}
+                : backupSummary.isExpired
+                  ? 'Expired'
+                  : backupSummary.hasRuns
+                    ? 'Historical'
+                    : backupSummary.hasActiveJob
+                      ? 'Configured backup'
+                      : 'No Backups'}
             </Badge>
           </div>
         </div>

--- a/apps/web/src/features/vms/backup/components/backup-overview.tsx
+++ b/apps/web/src/features/vms/backup/components/backup-overview.tsx
@@ -32,6 +32,8 @@ interface BackupOverviewProps {
   vm: VMWithBackupStatus
   backupJobs: BackupJob[]
   backupRuns: BackupRun[]
+  isBackupRunsLoading?: boolean
+  hasFetchedBackupRuns?: boolean
 }
 
 const formatDateTime = (dateString: string | null | undefined) => {
@@ -386,7 +388,12 @@ const BackupRunCard: React.FC<{ run: BackupRun; isLatest: boolean }> = ({ run, i
   )
 }
 
-export const BackupOverview: React.FC<BackupOverviewProps> = ({ backupJobs, backupRuns }) => {
+export const BackupOverview: React.FC<BackupOverviewProps> = ({
+  backupJobs,
+  backupRuns,
+  isBackupRunsLoading = false,
+  hasFetchedBackupRuns = false,
+}) => {
   const latestRun = React.useMemo(() => {
     if (backupRuns.length === 0) return null
 
@@ -500,7 +507,7 @@ export const BackupOverview: React.FC<BackupOverviewProps> = ({ backupJobs, back
     </Card>
   )
 
-  if (backupJobs.length === 0 && backupRuns.length === 0) {
+  if (backupJobs.length === 0 && backupRuns.length === 0 && !isBackupRunsLoading && hasFetchedBackupRuns) {
     return (
       <div className='flex items-center justify-center p-12 bg-gray-50 dark:bg-gray-900/20 rounded-lg border-2 border-dashed border-gray-300 dark:border-gray-700'>
         <div className='text-center space-y-3'>
@@ -522,9 +529,7 @@ export const BackupOverview: React.FC<BackupOverviewProps> = ({ backupJobs, back
           <TabsTrigger value='jobs' disabled={backupJobs.length === 0}>
             Backup Jobs ({backupJobs.length})
           </TabsTrigger>
-          <TabsTrigger value='runs' disabled={backupRuns.length === 0}>
-            Backup Runs ({backupRuns.length})
-          </TabsTrigger>
+          <TabsTrigger value='runs'>Backup Runs ({isBackupRunsLoading ? 'loading...' : backupRuns.length})</TabsTrigger>
         </TabsList>
 
         <TabsContent value='jobs' className='space-y-4'>
@@ -554,6 +559,8 @@ export const BackupOverview: React.FC<BackupOverviewProps> = ({ backupJobs, back
                   <BackupRunCard key={getBackupRunId(run) || index} run={run} isLatest={run === latestRun} />
                 ))}
             </div>
+          ) : isBackupRunsLoading ? (
+            <div className='text-center py-8 text-blue-600 dark:text-blue-300'>Loading backup runs...</div>
           ) : (
             <div className='text-center py-8 text-gray-500'>No backup runs found for this VM.</div>
           )}

--- a/apps/web/src/features/vms/backup/components/backup-status-display.tsx
+++ b/apps/web/src/features/vms/backup/components/backup-status-display.tsx
@@ -89,6 +89,7 @@ export const BackupStatusTableDisplay = ({ vm }: BackupStatusDisplayProps) => {
   const backupStatus = useBackupStatus(vm)
   const activeBackupStatus = useActiveBackupStatus(vm)
   const isActive = activeBackupStatus.hasActiveBackup
+  const isExpired = activeBackupStatus.hasExpiredBackup
   const isHistorical = activeBackupStatus.hasHistoricalBackup
   const isConfigured = activeBackupStatus.hasConfiguredBackup
 
@@ -123,6 +124,8 @@ export const BackupStatusTableDisplay = ({ vm }: BackupStatusDisplayProps) => {
             {backupStatus.lastBackupInfo.expiryTime ? formatDateTime(backupStatus.lastBackupInfo.expiryTime) : 'N/A'}
           </div>
         </>
+      ) : isExpired ? (
+        <div>Backup run exists but has expired</div>
       ) : isConfigured ? (
         <div>Backup job configured - no runs executed yet</div>
       ) : (
@@ -136,7 +139,9 @@ export const BackupStatusTableDisplay = ({ vm }: BackupStatusDisplayProps) => {
       <Tooltip>
         <TooltipTrigger asChild>
           <div>
-            {isConfigured ? (
+            {isExpired ? (
+              <Pill className='bg-red-100 text-red-800 border-red-200 cursor-pointer'>Expired</Pill>
+            ) : isConfigured ? (
               <Pill className='bg-blue-100 text-blue-800 border-blue-200 cursor-pointer'>Configured</Pill>
             ) : isActive ? (
               <Pill className='bg-green-100 text-green-800 dark:text-green-500 cursor-pointer'>Active</Pill>
@@ -168,30 +173,35 @@ export const BackupStatusDisplay = ({ vm, className }: BackupStatusDisplayProps)
   }
 
   const isActive = activeBackupStatus.hasActiveBackup
+  const isExpired = activeBackupStatus.hasExpiredBackup
   const isHistorical = activeBackupStatus.hasHistoricalBackup
   const isConfigured = activeBackupStatus.hasConfiguredBackup
 
   const containerStyles = cn(
     'mt-1 p-3 rounded-md relative overflow-hidden',
-    isConfigured
-      ? 'border-2 border-blue-400 bg-blue-50 dark:bg-blue-900/20'
-      : isActive
-        ? 'border-2 border-green-400 bg-green-50 dark:bg-green-900/20'
-        : isHistorical
-          ? 'border-2 border-orange-400 bg-orange-50 dark:bg-orange-900/20'
-          : 'border border-gray-200 dark:border-gray-700',
+    isExpired
+      ? 'border-2 border-red-400 bg-red-50 dark:bg-red-900/20'
+      : isConfigured
+        ? 'border-2 border-blue-400 bg-blue-50 dark:bg-blue-900/20'
+        : isActive
+          ? 'border-2 border-green-400 bg-green-50 dark:bg-green-900/20'
+          : isHistorical
+            ? 'border-2 border-orange-400 bg-orange-50 dark:bg-orange-900/20'
+            : 'border border-gray-200 dark:border-gray-700',
     className
   )
 
   const titleStyles = cn(
     'font-semibold text-sm mb-2 tracking-wide flex items-center',
-    isConfigured
-      ? 'text-blue-700 dark:text-blue-300'
-      : isActive
-        ? 'text-green-700 dark:text-green-300'
-        : isHistorical
-          ? 'text-orange-700 dark:text-orange-300'
-          : 'text-gray-700 dark:text-gray-300'
+    isExpired
+      ? 'text-red-700 dark:text-red-300'
+      : isConfigured
+        ? 'text-blue-700 dark:text-blue-300'
+        : isActive
+          ? 'text-green-700 dark:text-green-300'
+          : isHistorical
+            ? 'text-orange-700 dark:text-orange-300'
+            : 'text-gray-700 dark:text-gray-300'
   )
 
   const formatDateTime = (dateString: string) => {
@@ -203,6 +213,11 @@ export const BackupStatusDisplay = ({ vm, className }: BackupStatusDisplayProps)
       {isActive && (
         <div className='absolute top-0 right-0 bg-green-400 text-white text-xs px-2 py-1 rounded-bl-md font-medium'>
           ACTIVE
+        </div>
+      )}
+      {isExpired && (
+        <div className='absolute top-0 right-0 bg-red-400 text-white text-xs px-2 py-1 rounded-bl-md font-medium'>
+          EXPIRED
         </div>
       )}
       {isHistorical && (
@@ -217,10 +232,15 @@ export const BackupStatusDisplay = ({ vm, className }: BackupStatusDisplayProps)
       )}
 
       <h5 className={titleStyles}>
+        {isExpired && <span className='w-2 h-2 bg-red-400 rounded-full mr-2'></span>}
         {isConfigured && <span className='w-2 h-2 bg-blue-400 rounded-full mr-2'></span>}
         {isActive && !isConfigured && <span className='w-2 h-2 bg-green-400 rounded-full mr-2 animate-pulse'></span>}
         {isHistorical && <span className='w-2 h-2 bg-orange-400 rounded-full mr-2'></span>}
-        {isConfigured && !backupStatus.hasBackupRun ? 'Backup configured' : 'Last backup'}
+        {isExpired
+          ? 'Backup expired'
+          : isConfigured && !backupStatus.hasBackupRun
+            ? 'Backup configured'
+            : 'Last backup'}
       </h5>
 
       <div className='grid grid-cols-1 gap-2 text-xs'>
@@ -246,6 +266,11 @@ export const BackupStatusDisplay = ({ vm, className }: BackupStatusDisplayProps)
               }
             />
           </>
+        ) : isExpired ? (
+          <div className='text-center py-2'>
+            <p className='text-sm text-red-700 dark:text-red-300 font-medium'>Backup run expired</p>
+            <p className='text-xs text-gray-600 dark:text-gray-400 mt-1 mb-1'>A new backup run is required</p>
+          </div>
         ) : isConfigured ? (
           <div className='text-center py-2'>
             <p className='text-sm text-blue-700 dark:text-blue-300 font-medium'>Backup job configured</p>

--- a/apps/web/src/features/vms/backup/components/backup-status-display.tsx
+++ b/apps/web/src/features/vms/backup/components/backup-status-display.tsx
@@ -85,6 +85,35 @@ const NoBackupTableDisplay = () => (
   </div>
 )
 
+const LoadingBackupTableDisplay = ({ label = 'Loading backup...' }: { label?: string }) => (
+  <div>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div>
+          <Pill className='bg-blue-100 text-blue-800 border-blue-200 cursor-pointer animate-pulse'>{label}</Pill>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className='text-xs'>Fetching backup run details</div>
+      </TooltipContent>
+    </Tooltip>
+  </div>
+)
+
+const LoadingBackupDisplay = ({ label = 'Loading backup data...' }: { label?: string }) => (
+  <div className='mt-1 p-4 border border-blue-200 dark:border-blue-800 rounded-lg bg-blue-50 dark:bg-blue-900/20'>
+    <h5 className='font-semibold text-sm text-blue-700 dark:text-blue-300 tracking-wide'>Backup status</h5>
+    <div className='flex items-center justify-center py-2'>
+      <div className='text-center space-y-2'>
+        <div className='w-10 h-10 bg-blue-100 dark:bg-blue-800/40 rounded-full flex items-center justify-center mx-auto'>
+          <span className='w-4 h-4 rounded-full bg-blue-500 animate-pulse' />
+        </div>
+        <p className='text-sm text-blue-700 dark:text-blue-300 font-medium'>{label}</p>
+      </div>
+    </div>
+  </div>
+)
+
 export const BackupStatusTableDisplay = ({ vm }: BackupStatusDisplayProps) => {
   const backupStatus = useBackupStatus(vm)
   const activeBackupStatus = useActiveBackupStatus(vm)
@@ -92,10 +121,16 @@ export const BackupStatusTableDisplay = ({ vm }: BackupStatusDisplayProps) => {
   const isExpired = activeBackupStatus.hasExpiredBackup
   const isHistorical = activeBackupStatus.hasHistoricalBackup
   const isConfigured = activeBackupStatus.hasConfiguredBackup
+  const isHydrating = activeBackupStatus.isBackupInfoHydrating
 
-  // If no backup data is loaded, show no backup display
+  // Show loader while the VM backup status itself has not been hydrated.
   if (!backupStatus.isDataLoaded) {
-    return <NoBackupTableDisplay />
+    return <LoadingBackupTableDisplay />
+  }
+
+  // Show loader while active backup exists but latest run info is still hydrating.
+  if (isHydrating) {
+    return <LoadingBackupTableDisplay label='Loading active backup...' />
   }
 
   // If no backup job and no backup runs, show no backup display
@@ -162,9 +197,16 @@ export const BackupStatusDisplay = ({ vm, className }: BackupStatusDisplayProps)
   const activeBackupStatus = useActiveBackupStatus(vm)
   const backupStatus = useBackupStatus(vm)
 
-  // If no backup data is loaded, show no backup display
+  const isHydrating = activeBackupStatus.isBackupInfoHydrating
+
+  // Show loader while backup status has not been added to VM data yet.
   if (!backupStatus.isDataLoaded) {
-    return <NoBackupDisplay />
+    return <LoadingBackupDisplay />
+  }
+
+  // Show loader while active backup exists but run details are still loading.
+  if (isHydrating) {
+    return <LoadingBackupDisplay label='Loading active backup...' />
   }
 
   // If no backup job and no backup runs, show no backup display

--- a/apps/web/src/features/vms/backup/hooks/useBackupStatus.ts
+++ b/apps/web/src/features/vms/backup/hooks/useBackupStatus.ts
@@ -10,7 +10,18 @@ interface BackupStatusResult {
   hasBackupJob: boolean
   hasBackupRun: boolean
   hasActiveBackup: boolean
+  hasExpiredBackupRun: boolean
   lastBackupInfo?: LastBackupInfo | null
+}
+
+const isExpiredBackupInfo = (lastBackupInfo?: LastBackupInfo | null) => {
+  const expiryTime = lastBackupInfo?.expiryTime
+  if (!expiryTime) return false
+
+  const expiryDate = new Date(expiryTime)
+  if (Number.isNaN(expiryDate.getTime())) return false
+
+  return expiryDate.getTime() < Date.now()
 }
 
 /**
@@ -32,13 +43,16 @@ export const useBackupStatus = (vm: VMTableRow): BackupStatusResult => {
     const hasBackupJob = backupStatus.hasBackupJob
     const hasBackupRun = backupStatus.hasBackupRun
     const hasBackup = hasBackupJob || hasBackupRun
-    const hasActiveBackup = hasBackupJob // Active backup means VM has a backup job configured
+    const hasExpiredBackupRun = hasBackupRun && isExpiredBackupInfo(backupStatus.lastBackupInfo)
+    const hasNonExpiredBackupRun = hasBackupRun && !hasExpiredBackupRun
+    const hasActiveBackup = hasBackupJob && hasNonExpiredBackupRun
 
     return {
       hasBackup, // Overall backup status (true if job OR run exists)
       isDataLoaded: true, // Indicates data is available
       hasBackupJob,
       hasBackupRun,
+      hasExpiredBackupRun,
       hasActiveBackup, // True only if VM has backup job (actively being backed up)
       lastBackupInfo: backupStatus.lastBackupInfo,
     }
@@ -51,6 +65,7 @@ export const useBackupStatus = (vm: VMTableRow): BackupStatusResult => {
     hasBackupJob: false,
     hasBackupRun: false,
     hasActiveBackup: false,
+    hasExpiredBackupRun: false,
     lastBackupInfo: null,
   }
 }
@@ -74,11 +89,7 @@ export const getVMBackupStatus = (vm: VMTableRow): boolean => {
  * @returns Whether the VM has an active backup job
  */
 export const getVMActiveBackupStatus = (vm: VMTableRow): boolean => {
-  if ('backupStatus' in vm) {
-    const backupStatus = vm.backupStatus as { hasBackupJob: boolean; hasBackupRun: boolean }
-    return backupStatus.hasBackupJob
-  }
-  return false
+  return useBackupStatus(vm).hasActiveBackup
 }
 
 /**
@@ -92,8 +103,9 @@ export const useActiveBackupStatus = (vm: VMTableRow) => {
   return {
     hasActiveBackup: fullStatus.hasActiveBackup,
     isDataLoaded: fullStatus.isDataLoaded,
-    hasHistoricalBackup: fullStatus.hasBackupRun && !fullStatus.hasBackupJob, // Has runs but no job
-    hasConfiguredBackup: fullStatus.hasBackupJob && !fullStatus.hasBackupRun, // Has job but no runs
+    hasExpiredBackup: fullStatus.hasExpiredBackupRun,
+    hasHistoricalBackup: fullStatus.hasBackupRun && !fullStatus.hasBackupJob && !fullStatus.hasExpiredBackupRun,
+    hasConfiguredBackup: fullStatus.hasBackupJob && !fullStatus.hasBackupRun,
   }
 }
 

--- a/apps/web/src/features/vms/backup/hooks/useBackupStatus.ts
+++ b/apps/web/src/features/vms/backup/hooks/useBackupStatus.ts
@@ -11,6 +11,7 @@ interface BackupStatusResult {
   hasBackupRun: boolean
   hasActiveBackup: boolean
   hasExpiredBackupRun: boolean
+  isBackupInfoHydrating: boolean
   lastBackupInfo?: LastBackupInfo | null
 }
 
@@ -46,6 +47,12 @@ export const useBackupStatus = (vm: VMTableRow): BackupStatusResult => {
     const hasExpiredBackupRun = hasBackupRun && isExpiredBackupInfo(backupStatus.lastBackupInfo)
     const hasNonExpiredBackupRun = hasBackupRun && !hasExpiredBackupRun
     const hasActiveBackup = hasBackupJob && hasNonExpiredBackupRun
+    const hasHydrationRunIds = (backupStatus.relatedBackupJobs ?? []).some(
+      (job) => (job?.backupjob?.status?.backupRunIds ?? []).length > 0
+    )
+    const hasHydratedRelatedRuns = (backupStatus.relatedBackupRuns ?? []).length > 0
+    const isBackupInfoHydrating =
+      hasBackupJob && hasBackupRun && !backupStatus.lastBackupInfo && hasHydrationRunIds && !hasHydratedRelatedRuns
 
     return {
       hasBackup, // Overall backup status (true if job OR run exists)
@@ -54,6 +61,7 @@ export const useBackupStatus = (vm: VMTableRow): BackupStatusResult => {
       hasBackupRun,
       hasExpiredBackupRun,
       hasActiveBackup, // True only if VM has backup job (actively being backed up)
+      isBackupInfoHydrating,
       lastBackupInfo: backupStatus.lastBackupInfo,
     }
   }
@@ -66,6 +74,7 @@ export const useBackupStatus = (vm: VMTableRow): BackupStatusResult => {
     hasBackupRun: false,
     hasActiveBackup: false,
     hasExpiredBackupRun: false,
+    isBackupInfoHydrating: false,
     lastBackupInfo: null,
   }
 }
@@ -113,6 +122,7 @@ export const useActiveBackupStatus = (vm: VMTableRow) => {
   return {
     hasActiveBackup: fullStatus.hasActiveBackup,
     isDataLoaded: fullStatus.isDataLoaded,
+    isBackupInfoHydrating: fullStatus.isBackupInfoHydrating,
     hasExpiredBackup: fullStatus.hasExpiredBackupRun,
     hasHistoricalBackup: fullStatus.hasBackupRun && !fullStatus.hasBackupJob && !fullStatus.hasExpiredBackupRun,
     hasConfiguredBackup: fullStatus.hasBackupJob && !fullStatus.hasBackupRun,

--- a/apps/web/src/features/vms/backup/hooks/useBackupStatus.ts
+++ b/apps/web/src/features/vms/backup/hooks/useBackupStatus.ts
@@ -89,7 +89,17 @@ export const getVMBackupStatus = (vm: VMTableRow): boolean => {
  * @returns Whether the VM has an active backup job
  */
 export const getVMActiveBackupStatus = (vm: VMTableRow): boolean => {
-  return useBackupStatus(vm).hasActiveBackup
+  if (!('backupStatus' in vm)) return false
+
+  const backupStatus = vm.backupStatus as {
+    hasBackupJob: boolean
+    hasBackupRun: boolean
+    lastBackupInfo?: LastBackupInfo | null
+  }
+
+  const hasExpiredBackupRun = backupStatus.hasBackupRun && isExpiredBackupInfo(backupStatus.lastBackupInfo)
+  const hasNonExpiredBackupRun = backupStatus.hasBackupRun && !hasExpiredBackupRun
+  return backupStatus.hasBackupJob && hasNonExpiredBackupRun
 }
 
 /**

--- a/apps/web/src/features/vms/backup/services/backup-cache.ts
+++ b/apps/web/src/features/vms/backup/services/backup-cache.ts
@@ -1,0 +1,205 @@
+// FILE OVERVIEW:
+// ------------------------
+// This file defines a custom React hook `useBackupInfoHydration` that manages the hydration of backup information for virtual machines (VMs) in a web application.
+// The hook retrieves cached backup information from local storage, identifies VMs that require backup information hydration, and fetches the necessary backup run data to update the cache and provide a more complete backup status for each VM.
+
+import {
+  type LastBackupInfo,
+  getBackupRunActiveTargets,
+  getBackupRunInfo,
+} from '@/features/vms/backup/utils/backup-run'
+import { useRef, useState, useEffect, useMemo } from 'react'
+import { getVmExternalId } from '@/features/vms/utils/vms'
+import type { BackupRun, VirtualMachine } from '@ror/js-api-client'
+import type { VMWithBackupStatus } from '../utils/map-backup-to-vm'
+
+export const vmBackupUpCacheKey = 'vm-last-backup-info'
+export const vmBackupUpCacheTTL = 6 * 60 * 60 * 1000
+export const vmBackupRunBatchSize = 200
+export const runIdsPerJob = 3
+
+export type BackupInfoCacheEntry = LastBackupInfo & { cachedAt: number }
+export type BackupInfoCacheMap = Record<string, BackupInfoCacheEntry>
+
+type HydratableVm = VirtualMachine | VMWithBackupStatus
+
+const hasBackupStatus = (item: HydratableVm): item is VMWithBackupStatus => 'backupStatus' in item
+
+export const useBackupInfoHydration = (items: HydratableVm[]) => {
+  const [hydratedBackupInfoByVmId, setHydratedBackupInfoByVmId] = useState<BackupInfoCacheMap>({})
+  const requestedRunIdsRef = useRef<Set<string>>(new Set())
+  const hydrateInFlightRef = useRef(false)
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(vmBackupUpCacheKey)
+      if (!raw) return
+
+      const parsed = JSON.parse(raw) as BackupInfoCacheMap
+      const now = Date.now()
+      const next: BackupInfoCacheMap = {}
+
+      for (const [vmExternalId, entry] of Object.entries(parsed)) {
+        if (entry?.cachedAt && now - entry.cachedAt < vmBackupUpCacheTTL) {
+          next[vmExternalId] = entry
+        }
+      }
+
+      setHydratedBackupInfoByVmId(next)
+    } catch {
+      // Ignore invalid cache payload.
+    }
+  }, [])
+
+  const hydratedItems = useMemo(() => {
+    return items.map((item) => {
+      if (!hasBackupStatus(item)) {
+        return item
+      }
+
+      if (item.backupStatus?.lastBackupInfo) {
+        return item
+      }
+
+      const vmExternalId = getVmExternalId(item)
+      if (!vmExternalId) {
+        return item
+      }
+
+      const cached = hydratedBackupInfoByVmId[vmExternalId]
+      if (!cached) {
+        return item
+      }
+
+      return {
+        ...item,
+        backupStatus: {
+          ...item.backupStatus,
+          lastBackupInfo: {
+            startTime: cached.startTime,
+            endTime: cached.endTime,
+            expiryTime: cached.expiryTime,
+          },
+        },
+      }
+    })
+  }, [items, hydratedBackupInfoByVmId])
+
+  useEffect(() => {
+    if (hydrateInFlightRef.current) return
+
+    const vmCandidateRunIds = new Map<string, Set<string>>()
+    const candidateRunIds: string[] = []
+    const seenCandidateRunIds = new Set<string>()
+
+    for (const item of items) {
+      if (!hasBackupStatus(item)) continue
+
+      const backupStatus = item.backupStatus
+      if (!backupStatus?.hasBackupRun || backupStatus.lastBackupInfo) continue
+
+      const vmExternalId = getVmExternalId(item)
+      if (!vmExternalId || hydratedBackupInfoByVmId[vmExternalId]) continue
+
+      const runIdSet = new Set<string>()
+
+      for (const job of backupStatus.relatedBackupJobs ?? []) {
+        const runIds = job?.backupjob?.status?.backupRunIds ?? []
+        for (const runId of runIds.slice(0, runIdsPerJob)) {
+          if (!runId) continue
+          runIdSet.add(runId)
+        }
+      }
+
+      if (!runIdSet.size) continue
+
+      vmCandidateRunIds.set(vmExternalId, runIdSet)
+
+      for (const runId of runIdSet) {
+        if (requestedRunIdsRef.current.has(runId) || seenCandidateRunIds.has(runId)) continue
+        seenCandidateRunIds.add(runId)
+        candidateRunIds.push(runId)
+      }
+    }
+
+    if (!candidateRunIds.length || !vmCandidateRunIds.size) return
+
+    const runIdsBatch = candidateRunIds.slice(0, vmBackupRunBatchSize)
+    for (const runId of runIdsBatch) {
+      requestedRunIdsRef.current.add(runId)
+    }
+
+    hydrateInFlightRef.current = true
+
+    void (async () => {
+      try {
+        const response = await fetch('/api/vm-backup-runs', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ runIds: runIdsBatch }),
+        })
+
+        if (!response.ok) return
+
+        const payload = (await response.json()) as { backupRuns?: BackupRun[] }
+        const fetchedRuns = payload.backupRuns ?? []
+        if (!fetchedRuns.length) return
+
+        const now = Date.now()
+        const updates: BackupInfoCacheMap = {}
+
+        for (const [vmExternalId, runIdSet] of vmCandidateRunIds.entries()) {
+          let latestBackupInfo: LastBackupInfo | null = null
+          let latestTs = 0
+
+          for (const run of fetchedRuns) {
+            const runId = run?.backuprun?.id
+            if (!runId || !runIdSet.has(runId)) continue
+
+            const targets = getBackupRunActiveTargets(run)
+            const targetsVm = targets.some((target) => target.externalId === vmExternalId)
+            if (!targetsVm) continue
+
+            const info = getBackupRunInfo(run)
+            if (!info.startTime) continue
+
+            const ts = Date.parse(info.startTime)
+            if (!Number.isFinite(ts) || ts < latestTs) continue
+
+            latestTs = ts
+            latestBackupInfo = {
+              startTime: info.startTime,
+              endTime: info.endTime,
+              expiryTime: info.expiryTime,
+            }
+          }
+
+          if (latestBackupInfo) {
+            updates[vmExternalId] = {
+              ...latestBackupInfo,
+              cachedAt: now,
+            }
+          }
+        }
+
+        if (!Object.keys(updates).length) return
+
+        setHydratedBackupInfoByVmId((prev) => {
+          const next = { ...prev, ...updates }
+          try {
+            localStorage.setItem(vmBackupUpCacheKey, JSON.stringify(next))
+          } catch {
+            // Ignore storage quota/write errors.
+          }
+          return next
+        })
+      } catch {
+        // Keep page resilient if hydration fetch fails.
+      } finally {
+        hydrateInFlightRef.current = false
+      }
+    })()
+  }, [items, hydratedBackupInfoByVmId])
+
+  return hydratedItems
+}

--- a/apps/web/src/features/vms/backup/services/fetch-backupRuns-for-jobs.ts
+++ b/apps/web/src/features/vms/backup/services/fetch-backupRuns-for-jobs.ts
@@ -1,0 +1,62 @@
+import type { BackupJob, BackupRun } from '@ror/js-api-client'
+
+export async function fetchBackupRunsForJobs(
+  api: Awaited<ReturnType<typeof import('@/services/ror-api').getRorApi>>,
+  backupJobs: BackupJob[]
+) {
+  if (!backupJobs.length) {
+    return []
+  }
+
+  // Collect all unique backup run IDs from the jobs
+  const runIdSet = new Set<string>()
+  for (const job of backupJobs) {
+    const runIds = job?.backupjob?.status?.backupRunIds ?? []
+    for (const id of runIds) {
+      runIdSet.add(id)
+    }
+  }
+
+  if (!runIdSet.size) {
+    return []
+  }
+
+  // Fetch backup runs in batches to get the ones referenced by these jobs
+  // Start by fetching a reasonable amount and filtering by job IDs
+  const allRunIds = Array.from(runIdSet)
+  const batchSize = 500
+  const maxPages = 100
+
+  const fetchedRuns: BackupRun[] = []
+  const jobIdSet = new Set(allRunIds.slice(0, Math.min(50, allRunIds.length)))
+
+  for (let page = 0; page < maxPages; page++) {
+    const offset = page * batchSize
+    const params = new URLSearchParams()
+    params.set('limit', String(batchSize))
+    params.set('offset', String(offset))
+    params.set('order', 'desc')
+
+    const backupRunsRes = await api.backupRun.list(params)
+    const backupRuns: BackupRun[] = backupRunsRes?.resources ?? []
+
+    // Filter runs to only those referenced by our jobs
+    for (const run of backupRuns) {
+      const runId = run?.backuprun?.id
+      if (runId && allRunIds.includes(runId)) {
+        fetchedRuns.push(run)
+      }
+    }
+
+    if (backupRuns.length < batchSize) {
+      break
+    }
+
+    // Stop if we've fetched enough
+    if (fetchedRuns.length >= allRunIds.length) {
+      break
+    }
+  }
+
+  return fetchedRuns
+}

--- a/apps/web/src/features/vms/backup/services/fetch-backupRuns-for-jobs.ts
+++ b/apps/web/src/features/vms/backup/services/fetch-backupRuns-for-jobs.ts
@@ -1,5 +1,45 @@
 import type { BackupJob, BackupRun } from '@ror/js-api-client'
 
+const BACKUP_RUN_PAGE_SIZE = 500
+const BACKUP_RUN_MAX_PAGES = 100
+
+export async function fetchBackupRunsByIds(
+  api: Awaited<ReturnType<typeof import('@/services/ror-api').getRorApi>>,
+  runIds: string[]
+) {
+  const wantedIds = new Set(runIds.filter(Boolean))
+  if (!wantedIds.size) {
+    return []
+  }
+
+  const fetchedRuns: BackupRun[] = []
+
+  for (let page = 0; page < BACKUP_RUN_MAX_PAGES; page++) {
+    const offset = page * BACKUP_RUN_PAGE_SIZE
+    const params = new URLSearchParams()
+    params.set('limit', String(BACKUP_RUN_PAGE_SIZE))
+    params.set('offset', String(offset))
+    params.set('order', 'desc')
+
+    const backupRunsRes = await api.backupRun.list(params)
+    const backupRuns: BackupRun[] = backupRunsRes?.resources ?? []
+
+    for (const run of backupRuns) {
+      const runId = run?.backuprun?.id
+      if (runId && wantedIds.has(runId)) {
+        fetchedRuns.push(run)
+        wantedIds.delete(runId)
+      }
+    }
+
+    if (!wantedIds.size || backupRuns.length < BACKUP_RUN_PAGE_SIZE) {
+      break
+    }
+  }
+
+  return fetchedRuns
+}
+
 export async function fetchBackupRunsForJobs(
   api: Awaited<ReturnType<typeof import('@/services/ror-api').getRorApi>>,
   backupJobs: BackupJob[]
@@ -21,42 +61,6 @@ export async function fetchBackupRunsForJobs(
     return []
   }
 
-  // Fetch backup runs in batches to get the ones referenced by these jobs
-  // Start by fetching a reasonable amount and filtering by job IDs
   const allRunIds = Array.from(runIdSet)
-  const batchSize = 500
-  const maxPages = 100
-
-  const fetchedRuns: BackupRun[] = []
-  const jobIdSet = new Set(allRunIds.slice(0, Math.min(50, allRunIds.length)))
-
-  for (let page = 0; page < maxPages; page++) {
-    const offset = page * batchSize
-    const params = new URLSearchParams()
-    params.set('limit', String(batchSize))
-    params.set('offset', String(offset))
-    params.set('order', 'desc')
-
-    const backupRunsRes = await api.backupRun.list(params)
-    const backupRuns: BackupRun[] = backupRunsRes?.resources ?? []
-
-    // Filter runs to only those referenced by our jobs
-    for (const run of backupRuns) {
-      const runId = run?.backuprun?.id
-      if (runId && allRunIds.includes(runId)) {
-        fetchedRuns.push(run)
-      }
-    }
-
-    if (backupRuns.length < batchSize) {
-      break
-    }
-
-    // Stop if we've fetched enough
-    if (fetchedRuns.length >= allRunIds.length) {
-      break
-    }
-  }
-
-  return fetchedRuns
+  return fetchBackupRunsByIds(api, allRunIds)
 }

--- a/apps/web/src/features/vms/backup/utils/map-backup-to-vm.ts
+++ b/apps/web/src/features/vms/backup/utils/map-backup-to-vm.ts
@@ -1,6 +1,6 @@
 import { BackupJob, BackupRun, VirtualMachine } from '@ror/js-api-client'
 import { getVmExternalId } from '@/features/vms/utils/vms'
-import { getBackupJobActiveTargets } from '@/features/vms/backup/utils/backup-job'
+import { getBackupJobActiveTargets, getBackupJobAllRunIds } from '@/features/vms/backup/utils/backup-job'
 import { getBackupRunActiveTargets, getVMLastBackupInfo } from '@/features/vms/backup/utils/backup-run'
 import type { LastBackupInfo } from '@/features/vms/backup/utils/backup-run'
 
@@ -32,13 +32,18 @@ export function mapBackupToVM(
       return activeTargets.some((target) => target.externalId === vmExternalId)
     })
 
+    // Some VM pages only preload a sample of backup runs.
+    // Use backup job run IDs to avoid classifying active backups as only configured.
+    const hasBackupRunsFromJobs = relatedJobs.some((job) => getBackupJobAllRunIds(job).length > 0)
+    const hasBackupRun = relatedRuns.length > 0 || hasBackupRunsFromJobs
+
     const lastBackupInfo = getVMLastBackupInfo(relatedJobs, backupRuns, relatedRuns)
 
     return {
       ...vm,
       backupStatus: {
         hasBackupJob: relatedJobs.length > 0,
-        hasBackupRun: relatedRuns.length > 0,
+        hasBackupRun,
         lastBackupInfo,
         relatedBackupJobs: relatedJobs,
         relatedBackupRuns: relatedRuns,

--- a/apps/web/src/features/vms/config/page-view-options.tsx
+++ b/apps/web/src/features/vms/config/page-view-options.tsx
@@ -46,6 +46,7 @@ export const locationOptions: Option[] = [
 
 export const backupStatusOptions: Option[] = [
   { value: 'activeBackup', label: 'Active Backup' },
+  { value: 'expiredBackup', label: 'Expired Backup' },
   { value: 'historicalBackup', label: 'Historical Backup' },
   { value: 'configuredBackup', label: 'Configured Backup' },
   { value: 'noBackup', label: 'No Backup' },

--- a/apps/web/src/hooks/use-display-data.ts
+++ b/apps/web/src/hooks/use-display-data.ts
@@ -29,9 +29,7 @@ export function useDisplayData<T>(domain: string) {
       if (stored) {
         const parsed = JSON.parse(stored) as T[]
         // Only update if different to avoid unnecessary re-renders
-        if (JSON.stringify(parsed) !== JSON.stringify(selectedDisplayData)) {
-          setSelectedDisplayData(parsed)
-        }
+        setSelectedDisplayData((prev) => (JSON.stringify(parsed) !== JSON.stringify(prev) ? parsed : prev))
       }
     } catch {
       // ignore

--- a/apps/web/src/utils/backup-run-search-actions.ts
+++ b/apps/web/src/utils/backup-run-search-actions.ts
@@ -8,24 +8,42 @@ import {
   getBackupRunMappedBackupJobId,
 } from '@/features/vms/backup/utils/backup-run'
 
+const SEARCH_PAGE_SIZE = 500
+const MAX_SEARCH_PAGES = 40
+
+const getPageParams = (offset: number, limit: number) => {
+  const params = new URLSearchParams()
+  params.set('limit', String(limit))
+  params.set('offset', String(offset))
+  params.set('order', 'desc')
+  return params
+}
+
 export async function searchBackupRunById(id: string): Promise<BackupRun | null> {
   try {
     const api = await getRorApi()
 
-    // Search for backup run with specific ID
-    const params = new URLSearchParams()
-    params.set('limit', '1000') // Large limit to catch the specific item
-    params.set('offset', '0')
+    for (let page = 0; page < MAX_SEARCH_PAGES; page++) {
+      const offset = page * SEARCH_PAGE_SIZE
+      const params = getPageParams(offset, SEARCH_PAGE_SIZE)
 
-    const backupRunsRes = await api.backupRun.list(params)
-    const backupRuns: BackupRun[] = backupRunsRes?.resources ?? []
+      const backupRunsRes = await api.backupRun.list(params)
+      const backupRuns: BackupRun[] = backupRunsRes?.resources ?? []
 
-    // Find the specific backup run by ID or mapped backup job ID
-    const found = backupRuns.find(
-      (run) => getBackupRunId(run) === id || getBackupRunMappedBackupJobId(run) === id || run.metadata?.uid === id
-    )
+      const found = backupRuns.find(
+        (run) => getBackupRunId(run) === id || getBackupRunMappedBackupJobId(run) === id || run.metadata?.uid === id
+      )
 
-    return found || null
+      if (found) {
+        return found
+      }
+
+      if (backupRuns.length < SEARCH_PAGE_SIZE) {
+        break
+      }
+    }
+
+    return null
   } catch (error) {
     console.error('Error searching for backup run:', error)
     return null
@@ -36,24 +54,35 @@ export async function searchBackupRunsByQuery(query: string, limit: number = 50)
   try {
     const api = await getRorApi()
 
-    const params = new URLSearchParams()
-    params.set('limit', String(limit * 2)) // Get more items to search through
-    params.set('offset', '0')
-
-    const backupRunsRes = await api.backupRun.list(params)
-    const backupRuns: BackupRun[] = backupRunsRes?.resources ?? []
-
-    // Filter by query (ID match or source match)
     const queryLower = query.toLowerCase()
-    const filtered = backupRuns.filter((run) => {
-      const id = getBackupRunId(run).toLowerCase()
-      const source = getBackupRunSource(run).toLowerCase()
-      const backupJobId = getBackupRunMappedBackupJobId(run).toLowerCase()
+    const matches: BackupRun[] = []
 
-      return id.includes(queryLower) || source.includes(queryLower) || backupJobId.includes(queryLower)
-    })
+    for (let page = 0; page < MAX_SEARCH_PAGES; page++) {
+      const offset = page * SEARCH_PAGE_SIZE
+      const params = getPageParams(offset, SEARCH_PAGE_SIZE)
 
-    return filtered.slice(0, limit)
+      const backupRunsRes = await api.backupRun.list(params)
+      const backupRuns: BackupRun[] = backupRunsRes?.resources ?? []
+
+      for (const run of backupRuns) {
+        const id = getBackupRunId(run).toLowerCase()
+        const source = getBackupRunSource(run).toLowerCase()
+        const backupJobId = getBackupRunMappedBackupJobId(run).toLowerCase()
+
+        if (id.includes(queryLower) || source.includes(queryLower) || backupJobId.includes(queryLower)) {
+          matches.push(run)
+          if (matches.length >= limit) {
+            return matches
+          }
+        }
+      }
+
+      if (backupRuns.length < SEARCH_PAGE_SIZE) {
+        break
+      }
+    }
+
+    return matches
   } catch (error) {
     console.error('Error searching backup runs:', error)
     return []

--- a/apps/web/src/utils/vms-actions.ts
+++ b/apps/web/src/utils/vms-actions.ts
@@ -35,7 +35,7 @@ export async function loadMoreVMs({ offset, limit, sort, order, search }: LoadMo
   const [vmRes, backupJobsRes, backupRunsRes] = await Promise.all([
     api.virtualMachine.list(params),
     fetchBackupJobs(api, { page: 1, limit: 10000, order: 'asc' }).catch(() => ({ backupJobs: [] })),
-    fetchBackupRuns(api, { page: 1, limit: 10000, order: 'asc' }).catch(() => ({ backupRuns: [] })),
+    fetchBackupRuns(api, { page: 1, limit: 500, order: 'desc' }).catch(() => ({ backupRuns: [] })),
   ])
 
   const vms: VirtualMachine[] = vmRes?.resources ?? []

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -14,6 +14,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "ignoreDeprecations": "6.0",
     "plugins": [
       {
         "name": "next"

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -14,7 +14,6 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "ignoreDeprecations": "6.0",
     "plugins": [
       {
         "name": "next"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4439,7 +4439,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
@@ -4481,7 +4480,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4502,7 +4500,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4523,7 +4520,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4544,7 +4540,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4565,7 +4560,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4586,7 +4580,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4607,7 +4600,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4628,7 +4620,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4649,7 +4640,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4670,7 +4660,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4691,7 +4680,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4712,7 +4700,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4733,7 +4720,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4748,7 +4734,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18305,8 +18290,7 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/node-int64": {
       "version": "0.4.0",


### PR DESCRIPTION
This PR resolves the issue with backupRuns not being fetched inline with VMs which resulted in wrong status on most VMs backup.
<img width="792" height="106" alt="image" src="https://github.com/user-attachments/assets/ae207848-5f41-4f0f-a858-c43abb45f931" />

This has been solved by adding a backupCache-hook to provide backupinformation to the VM to complete the status. The cache backup-information is stored in the local storage under the key='vm-last-backup-info'. 
If the cache has not fetched the backupRuns that are needed, the VM card/list will show "active backup" by looking at the VMWithBackupStatus JSON and looking up the backupRun ids listed here. 

Also added a new backupStatus = backup expired, if the backupRun that was last run on the VM has reached it expired date, and no new backupRun has been found. 
<img width="370" height="146" alt="image" src="https://github.com/user-attachments/assets/5c481d5f-d559-48cd-a6e7-1a82fdf04cb7" />

Release out in beta
