### PR TITLE
Implement functionality to favorite items

### DIFF
--- a/apps/web/src/components/ui/favorite-star.tsx
+++ b/apps/web/src/components/ui/favorite-star.tsx
@@ -1,15 +1,61 @@
+import { addFavoriteItem, removeFavoriteItem } from '@/features/dashboard/utils/dashboard-localstorage'
 import { cn } from '@/utils/clsxm'
+import { getSavedPreference, removePreference, savePreference } from '@/utils/local-storage'
 import { Star } from 'lucide-react'
+import { useEffect, useState } from 'react'
 
 interface FavoriteStarProps {
+  domain: string
+  itemId: string
   className?: string
   favorited?: boolean
+  scale?:
+    | 'scale-0'
+    | 'scale-50'
+    | 'scale-75'
+    | 'scale-90'
+    | 'scale-95'
+    | 'scale-100'
+    | 'scale-105'
+    | 'scale-110'
+    | 'scale-125'
+    | 'scale-150'
+    | 'scale-200'
 }
 
-export const FavoriteStar = ({ className, favorited }: FavoriteStarProps) => {
+function checkIfFavorited(domain: string, itemId: string) {
+  const items = getSavedPreference(`${domain}:favorite`, [] as string[])
+  return items.includes(itemId)
+}
+
+export const FavoriteStar = ({ domain, itemId, className, scale = 'scale-100' }: FavoriteStarProps) => {
+  const [favorited, setFavorited] = useState(false)
+
+  useEffect(() => {
+    const items = getSavedPreference(`${domain}:favorite`, [] as string[])
+    setFavorited(items.includes(itemId))
+  }, [domain, itemId])
+
+  function toggleFavoriteLocalstorage(e: React.MouseEvent<HTMLButtonElement>) {
+    e.stopPropagation()
+    e.nativeEvent.stopImmediatePropagation()
+    e.preventDefault()
+
+    if (favorited) {
+      addFavoriteItem(itemId, domain)
+      setFavorited(false)
+    } else {
+      removeFavoriteItem(itemId, domain)
+      setFavorited(true)
+    }
+  }
+
   return (
-    <div className={cn('h-13 w-13 flex items-center justify-center', className)}>
-      <Star className={cn(favorited && 'fill-yellow-500', 'h-11 w-11')} />
-    </div>
+    <button
+      className={cn('h-13 w-13 flex items-center justify-center', className)}
+      onClick={toggleFavoriteLocalstorage}
+    >
+      <Star className={cn(favorited && 'fill-yellow-500', 'w-full h-full hover:fill-yellow-500', scale)} />
+    </button>
   )
 }

--- a/apps/web/src/components/ui/favorite-star.tsx
+++ b/apps/web/src/components/ui/favorite-star.tsx
@@ -10,7 +10,6 @@ interface FavoriteStarProps {
   domain: string
   itemId: string
   className?: string
-  favorited?: boolean
   scale?:
     | 'scale-0'
     | 'scale-50'

--- a/apps/web/src/components/ui/favorite-star.tsx
+++ b/apps/web/src/components/ui/favorite-star.tsx
@@ -42,10 +42,10 @@ export const FavoriteStar = ({ domain, itemId, className, scale = 'scale-100' }:
     e.preventDefault()
 
     if (favorited) {
-      addFavoriteItem(itemId, domain)
+      removeFavoriteItem(itemId, domain)
       setFavorited(false)
     } else {
-      removeFavoriteItem(itemId, domain)
+      addFavoriteItem(itemId, domain)
       setFavorited(true)
     }
   }

--- a/apps/web/src/components/ui/favorite-star.tsx
+++ b/apps/web/src/components/ui/favorite-star.tsx
@@ -55,6 +55,8 @@ export const FavoriteStar = ({ domain, itemId, className, scale = 'scale-100' }:
       type='button'
       className={cn('h-13 w-13 flex items-center justify-center', className)}
       onClick={toggleFavoriteLocalstorage}
+      aria-label={favorited ? 'Remove from favorites' : 'Add to favorites'}
+      aria-pressed={favorited}
     >
       <Star className={cn(favorited && 'fill-yellow-500', 'w-full h-full hover:fill-yellow-500', scale)} />
     </button>

--- a/apps/web/src/components/ui/favorite-star.tsx
+++ b/apps/web/src/components/ui/favorite-star.tsx
@@ -1,0 +1,15 @@
+import { cn } from '@/utils/clsxm'
+import { Star } from 'lucide-react'
+
+interface FavoriteStarProps {
+  className?: string
+  favorited?: boolean
+}
+
+export const FavoriteStar = ({ className, favorited }: FavoriteStarProps) => {
+  return (
+    <div className={cn('h-13 w-13 flex items-center justify-center', className)}>
+      <Star className={cn(favorited && 'fill-yellow-500', 'h-11 w-11')} />
+    </div>
+  )
+}

--- a/apps/web/src/components/ui/favorite-star.tsx
+++ b/apps/web/src/components/ui/favorite-star.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { addFavoriteItem, removeFavoriteItem } from '@/features/dashboard/utils/dashboard-localstorage'
 import { cn } from '@/utils/clsxm'
 import { getSavedPreference } from '@/utils/local-storage'
@@ -21,11 +23,6 @@ interface FavoriteStarProps {
     | 'scale-125'
     | 'scale-150'
     | 'scale-200'
-}
-
-function checkIfFavorited(domain: string, itemId: string) {
-  const items = getSavedPreference(`${domain}:favorite`, [] as string[])
-  return items.includes(itemId)
 }
 
 export const FavoriteStar = ({ domain, itemId, className, scale = 'scale-100' }: FavoriteStarProps) => {
@@ -55,6 +52,8 @@ export const FavoriteStar = ({ domain, itemId, className, scale = 'scale-100' }:
       type='button'
       className={cn('h-13 w-13 flex items-center justify-center', className)}
       onClick={toggleFavoriteLocalstorage}
+      aria-label={favorited ? 'Remove from favorites' : 'Add to favorites'}
+      aria-pressed={favorited}
     >
       <Star className={cn(favorited && 'fill-yellow-500', 'w-full h-full hover:fill-yellow-500', scale)} />
     </button>

--- a/apps/web/src/components/ui/favorite-star.tsx
+++ b/apps/web/src/components/ui/favorite-star.tsx
@@ -52,6 +52,7 @@ export const FavoriteStar = ({ domain, itemId, className, scale = 'scale-100' }:
 
   return (
     <button
+      type='button'
       className={cn('h-13 w-13 flex items-center justify-center', className)}
       onClick={toggleFavoriteLocalstorage}
     >

--- a/apps/web/src/components/ui/favorite-star.tsx
+++ b/apps/web/src/components/ui/favorite-star.tsx
@@ -1,6 +1,6 @@
 import { addFavoriteItem, removeFavoriteItem } from '@/features/dashboard/utils/dashboard-localstorage'
 import { cn } from '@/utils/clsxm'
-import { getSavedPreference, removePreference, savePreference } from '@/utils/local-storage'
+import { getSavedPreference } from '@/utils/local-storage'
 import { Star } from 'lucide-react'
 import { useEffect, useState } from 'react'
 

--- a/apps/web/src/features/cluster/components/cluster-card.tsx
+++ b/apps/web/src/features/cluster/components/cluster-card.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 import { Pill } from '@/components/shadcn/pill'
 import { cn } from '@/utils/clsxm'
 import type { ClusterListViewRowType } from '@ror/js-api-client'
-import { Dot, Star } from 'lucide-react'
+import { Dot } from 'lucide-react'
 import type { ClusterCardDisplayData } from '../types/display-data'
 import {
   getArgocdUrlView,
@@ -43,7 +43,7 @@ import { useRouter } from 'next/navigation'
 import { ResourceBar } from './resource-bar'
 import { ExternalToolButton } from './external-tool-button'
 import { RorCliButton } from './ror-cli-button'
-import { FavoriteStar, StarCircle } from '@/components/ui/favorite-star'
+import { FavoriteStar } from '@/components/ui/favorite-star'
 import { randomUUID } from 'crypto'
 
 function Card({ className, ...props }: React.ComponentProps<'div'>) {

--- a/apps/web/src/features/cluster/components/cluster-card.tsx
+++ b/apps/web/src/features/cluster/components/cluster-card.tsx
@@ -44,7 +44,6 @@ import { ResourceBar } from './resource-bar'
 import { ExternalToolButton } from './external-tool-button'
 import { RorCliButton } from './ror-cli-button'
 import { FavoriteStar } from '@/components/ui/favorite-star'
-import { randomUUID } from 'crypto'
 
 function Card({ className, ...props }: React.ComponentProps<'div'>) {
   return (
@@ -126,7 +125,7 @@ const infoSectionCls =
  * @returns A clickable card component linking to the cluster details page.
  */
 const ClusterCard = ({ className, cluster, displayData }: ClusterCardProps) => {
-  const clusterUid = getClusterUidView(cluster) || randomUUID()
+  const clusterUid = getClusterUidView(cluster) || globalThis.crypto.randomUUID()
   const clusterName = getClusterNameView(cluster) || missingText
   const provider = getProviderView(cluster) || missingText
   const datacenter = getDatacenterView(cluster) || missingText

--- a/apps/web/src/features/cluster/components/cluster-card.tsx
+++ b/apps/web/src/features/cluster/components/cluster-card.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 import { Pill } from '@/components/shadcn/pill'
 import { cn } from '@/utils/clsxm'
 import type { ClusterListViewRowType } from '@ror/js-api-client'
-import { Dot } from 'lucide-react'
+import { Dot, Star } from 'lucide-react'
 import type { ClusterCardDisplayData } from '../types/display-data'
 import {
   getArgocdUrlView,
@@ -43,6 +43,7 @@ import { useRouter } from 'next/navigation'
 import { ResourceBar } from './resource-bar'
 import { ExternalToolButton } from './external-tool-button'
 import { RorCliButton } from './ror-cli-button'
+import { FavoriteStar, StarCircle } from '@/components/ui/favorite-star'
 
 function Card({ className, ...props }: React.ComponentProps<'div'>) {
   return (
@@ -191,17 +192,24 @@ const ClusterCard = ({ className, cluster, displayData }: ClusterCardProps) => {
         }
       }}
     >
-      <CardHeader className='m-0 mb-7 p-0 w-full'>
-        <CardTitle className={cn('text-2xl rounded-t-xl px-6 py-2 flex', envColor[0], envColor[1])}>
-          {(clusterName || 'Unnamed Cluster') as string}
-        </CardTitle>
-        <HealthCircle className='ml-auto mr-4 -mt-6 w-13 h-13 ' healthCondition={healthCondition} />
+      <CardHeader
+        className={cn(
+          'h-15 pl-6 pr-2 py-2 m-0 mb-7 w-full flex justify-between items-center rounded-t-xl',
+          envColor[0],
+          envColor[1]
+        )}
+      >
+        <CardTitle className='text-xl'>{(clusterName || 'Unnamed Cluster') as string}</CardTitle>
+        <div className='flex justify-end gap-2'>
+          <HealthCircle className='w-11 h-11' healthCondition={healthCondition} />
+          <FavoriteStar className='w-11 h-11' favorited />
+        </div>
       </CardHeader>
 
       <CardContent className='text-sm flex flex-col gap-3'>
         {basicItems.length > 0 && (
           <>
-            <section className='flex items-center gap-2'>
+            <section className='flex items-center gap-1'>
               {basicItems.map((item, index) => (
                 <React.Fragment key={index}>
                   {index > 0 && <Dot />}

--- a/apps/web/src/features/cluster/components/cluster-card.tsx
+++ b/apps/web/src/features/cluster/components/cluster-card.tsx
@@ -44,6 +44,7 @@ import { ResourceBar } from './resource-bar'
 import { ExternalToolButton } from './external-tool-button'
 import { RorCliButton } from './ror-cli-button'
 import { FavoriteStar, StarCircle } from '@/components/ui/favorite-star'
+import { randomUUID } from 'crypto'
 
 function Card({ className, ...props }: React.ComponentProps<'div'>) {
   return (
@@ -125,6 +126,7 @@ const infoSectionCls =
  * @returns A clickable card component linking to the cluster details page.
  */
 const ClusterCard = ({ className, cluster, displayData }: ClusterCardProps) => {
+  const clusterUid = getClusterUidView(cluster) || randomUUID()
   const clusterName = getClusterNameView(cluster) || missingText
   const provider = getProviderView(cluster) || missingText
   const datacenter = getDatacenterView(cluster) || missingText
@@ -192,18 +194,18 @@ const ClusterCard = ({ className, cluster, displayData }: ClusterCardProps) => {
         }
       }}
     >
-      <CardHeader
-        className={cn(
-          'h-15 pl-6 pr-2 py-2 m-0 mb-7 w-full flex justify-between items-center rounded-t-xl',
-          envColor[0],
-          envColor[1]
-        )}
-      >
-        <CardTitle className='text-xl'>{(clusterName || 'Unnamed Cluster') as string}</CardTitle>
-        <div className='flex justify-end gap-2'>
-          <HealthCircle className='w-11 h-11' healthCondition={healthCondition} />
-          <FavoriteStar className='w-11 h-11' favorited />
-        </div>
+      <CardHeader className='m-0 mb-7 p-0 w-full'>
+        <CardTitle
+          className={cn(
+            'text-2xl rounded-t-xl pl-2 pr-6 py-2 flex items-center gap-1.5 h-14',
+            envColor[0],
+            envColor[1]
+          )}
+        >
+          <FavoriteStar domain='cluster' itemId={clusterUid} className='w-11 h-11' scale='scale-75' />
+          {(clusterName || 'Unnamed Cluster') as string}
+        </CardTitle>
+        <HealthCircle className='ml-auto mr-4 -mt-7 w-13 h-13' healthCondition={healthCondition} />
       </CardHeader>
 
       <CardContent className='text-sm flex flex-col gap-3'>

--- a/apps/web/src/features/dashboard/utils/dashboard-localstorage.ts
+++ b/apps/web/src/features/dashboard/utils/dashboard-localstorage.ts
@@ -32,16 +32,16 @@ export function addOverviewItem(item: OverviewItem): OverviewItem[] {
 
 export function addFavoriteItem(itemId: string, domain: string) {
   const items = getSavedPreference(`${domain}:favorite`, [] as string[])
-  if (!items.includes(itemId)) return items
-  const updated = items.filter((i) => i !== itemId)
+  if (items.includes(itemId)) return items
+  const updated = [...items, itemId]
   savePreference(`${domain}:favorite`, JSON.stringify(updated))
   return updated
 }
 
 export function removeFavoriteItem(itemId: string, domain: string) {
   const items = getSavedPreference(`${domain}:favorite`, [] as string[])
-  if (items.includes(itemId)) return items
-  const updated = [...items, itemId]
+  if (!items.includes(itemId)) return items
+  const updated = items.filter((i) => i !== itemId)
   savePreference(`${domain}:favorite`, JSON.stringify(updated))
   return updated
 }

--- a/apps/web/src/features/dashboard/utils/dashboard-localstorage.ts
+++ b/apps/web/src/features/dashboard/utils/dashboard-localstorage.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { OverviewItem, overviewItemsValues } from '../types/items'
+import { getSavedPreference, savePreference } from '@/utils/local-storage'
 
 export function getOverviewItems(): OverviewItem[] {
   if (typeof window === 'undefined') return [...overviewItemsValues]
@@ -26,5 +27,21 @@ export function addOverviewItem(item: OverviewItem): OverviewItem[] {
   if (items.includes(item)) return items
   const updated = [...items, item]
   window.localStorage.setItem('dashboard:overviewItems', JSON.stringify(updated))
+  return updated
+}
+
+export function addFavoriteItem(itemId: string, domain: string) {
+  const items = getSavedPreference(`${domain}:favorite`, [] as string[])
+  if (!items.includes(itemId)) return items
+  const updated = items.filter((i) => i !== itemId)
+  savePreference(`${domain}:favorite`, JSON.stringify(updated))
+  return updated
+}
+
+export function removeFavoriteItem(itemId: string, domain: string) {
+  const items = getSavedPreference(`${domain}:favorite`, [] as string[])
+  if (items.includes(itemId)) return items
+  const updated = [...items, itemId]
+  savePreference(`${domain}:favorite`, JSON.stringify(updated))
   return updated
 }

--- a/apps/web/src/utils/local-storage.ts
+++ b/apps/web/src/utils/local-storage.ts
@@ -9,21 +9,17 @@
  * @typeParam T - The expected type of the stored value
  */
 export function getSavedPreference<T>(key: string, fallback: T): T {
-  if (window.localStorage.getItem(key)) {
-    const value = window.localStorage.getItem(key) as T
-    // Booleans are saved as strings, therefore we need to parse them
-    if (value === 'true') {
-      return true as T
-    } else if (value === 'false') {
-      return false as T
-    } else {
-      return value
-    }
+  if (typeof window === 'undefined') return fallback
+  const raw = window.localStorage.getItem(key)
+  if (!raw) return fallback
+  if (raw === 'true') return true as T
+  if (raw === 'false') return false as T
+  try {
+    return JSON.parse(raw) as T
+  } catch {
+    return raw as T
   }
-
-  return fallback
 }
-
 /**
  * Save a preference value to local storage
  * @param key - The key to store the value under in localStorage
@@ -31,6 +27,7 @@ export function getSavedPreference<T>(key: string, fallback: T): T {
  * @typeParam T - The type of value being stored (must extend string)
  */
 export function savePreference<T extends string>(key: string, value: T): void {
+  if (typeof window === 'undefined') return
   window.localStorage.setItem(key, value)
 }
 
@@ -42,5 +39,6 @@ export function savePreference<T extends string>(key: string, value: T): void {
  * @returns void
  */
 export function removePreference(key: string): void {
+  if (typeof window === 'undefined') return
   window.localStorage.removeItem(key)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4439,6 +4439,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
@@ -4480,6 +4481,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4500,6 +4502,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4520,6 +4523,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4540,6 +4544,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4560,6 +4565,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4580,6 +4586,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4600,6 +4607,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4620,6 +4628,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4640,6 +4649,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4660,6 +4670,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4680,6 +4691,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4700,6 +4712,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4720,6 +4733,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -4734,6 +4748,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18290,7 +18305,8 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/node-int64": {
       "version": "0.4.0",


### PR DESCRIPTION
This PR aims to add functionality to favorite items. Additionally it has functionality to remove an item from favorites. This is saved in localstorage. The add and remove functions are located in the `dashboard-localstorage.ts` file. The add and remove functionality is added to `FavoriteStar`, which is added to the cluster card.

<img width="1217" height="716" alt="image" src="https://github.com/user-attachments/assets/0e4987ef-b8b9-4744-b8ac-43a5af63a0d0" />
