### PR TITLE
Fix bug when no clusters are present

### DIFF
--- a/apps/web/src/app/(protected)/clusters/[id]/layout.tsx
+++ b/apps/web/src/app/(protected)/clusters/[id]/layout.tsx
@@ -5,6 +5,7 @@
  */
 
 import { cache, Fragment, ReactNode } from 'react'
+import { redirect } from 'next/navigation'
 import { routes } from '@/config/routes'
 import { ClusterHeader } from '@/features/cluster/components/cluster-header'
 import { ClusterProvider } from '@/context/cluster-context'
@@ -96,6 +97,9 @@ export default async function ClusterPageLayout({ params, children }: ClusterPag
   try {
     const clusterList = (await fetchCluster(id)) as ClusterListItemView
     const cluster = clusterList.rows[0]
+    if (!cluster) {
+      redirect('/clusters')
+    }
     const clusterId = cluster.clusterId?.fieldValue || 'missing'
     const tabs = createTabNavigationItems(clusterId)
     const clusterContextValue = { cluster }

--- a/packages/js-api-client/src/core/validation.ts
+++ b/packages/js-api-client/src/core/validation.ts
@@ -27,13 +27,16 @@ export function validateResponse<T>(data: unknown, schema: z.ZodType<T>): T {
     // like when the user does not have access to any clusters.
     // This could benefit from being fixed in the API, but for now we handle it here.
     // TODO: Ask Håvard or Roger if this should be fixed in the API when they are back from holidays.
-    if (
-      typeof data === 'object' &&
-      data !== null &&
-      Object.keys(data).length === 0 &&
-      schema.safeParse({ resources: [] }).success
-    ) {
-      return schema.parse({ resources: [] })
+    if (typeof data === 'object' && data !== null && Object.keys(data).length === 0) {
+      // Handle resource-based schemas (e.g. kubernetesClusters)
+      if (schema.safeParse({ resources: [] }).success) {
+        return schema.parse({ resources: [] })
+      }
+      // Handle view-based schemas (e.g. clusterListView, clusterListItemView)
+      const emptyView = { type: '', columns: [], rows: [] }
+      if (schema.safeParse(emptyView).success) {
+        return schema.parse(emptyView)
+      }
     }
 
     return schema.parse(data)

--- a/packages/js-api-client/src/core/validation.ts
+++ b/packages/js-api-client/src/core/validation.ts
@@ -27,16 +27,13 @@ export function validateResponse<T>(data: unknown, schema: z.ZodType<T>): T {
     // like when the user does not have access to any clusters.
     // This could benefit from being fixed in the API, but for now we handle it here.
     // TODO: Ask Håvard or Roger if this should be fixed in the API when they are back from holidays.
-    if (typeof data === 'object' && data !== null && Object.keys(data).length === 0) {
-      // Handle resource-based schemas (e.g. kubernetesClusters)
-      if (schema.safeParse({ resources: [] }).success) {
-        return schema.parse({ resources: [] })
-      }
-      // Handle view-based schemas (e.g. clusterListView, clusterListItemView)
-      const emptyView = { type: '', columns: [], rows: [] }
-      if (schema.safeParse(emptyView).success) {
-        return schema.parse(emptyView)
-      }
+    if (
+      typeof data === 'object' &&
+      data !== null &&
+      Object.keys(data).length === 0 &&
+      schema.safeParse({ resources: [] }).success
+    ) {
+      return schema.parse({ resources: [] })
     }
 
     return schema.parse(data)

--- a/packages/js-api-client/src/schemas/views/clusterlist.ts
+++ b/packages/js-api-client/src/schemas/views/clusterlist.ts
@@ -47,6 +47,6 @@ export const ClusterListViewSchema = z
   .object({
     type: z.string(),
     columns: z.array(ViewColumn),
-    rows: z.array(ClusterListViewRow),
+    rows: z.array(ClusterListViewRow).default([]),
   })
   .loose()

--- a/packages/js-api-client/src/schemas/views/clusterlistitem.ts
+++ b/packages/js-api-client/src/schemas/views/clusterlistitem.ts
@@ -50,6 +50,6 @@ export const ClusterListItemViewSchema = z
   .object({
     type: z.string(),
     columns: z.array(ViewColumn),
-    rows: z.array(ClusterListItemViewRow),
+    rows: z.array(ClusterListItemViewRow).default([]),
   })
   .loose()


### PR DESCRIPTION
Fix was implemented by adding [] as the standard return if a user has no clusters