### PR TITLE
Sort on relevance from fuzzy search

### DIFF
--- a/apps/web/src/app/(protected)/clusters/page-view.tsx
+++ b/apps/web/src/app/(protected)/clusters/page-view.tsx
@@ -180,8 +180,8 @@ export const PageView = ({ className, clusters, params }: PageViewProps) => {
 
   const displayedItems = useMemo(() => {
     if (!searchResults?.length) return sortedItems
-    const ids = new Set(searchResults.map(getClusterIdView))
-    return sortedItems.filter((c) => ids.has(getClusterIdView(c)))
+    const ids = new Set(sortedItems.map(getClusterIdView))
+    return searchResults.filter((c) => ids.has(getClusterIdView(c)))
   }, [sortedItems, searchResults])
 
   const effectiveDisplayData = (


### PR DESCRIPTION
Previously, the items were sorted based on the sort function, not search function when a person searched. This needed to be fixed, and it now works.