### PR TITLE
Fix vm list view-state

### DIFF
--- a/apps/web/src/app/(protected)/vms/page-view.tsx
+++ b/apps/web/src/app/(protected)/vms/page-view.tsx
@@ -291,6 +291,7 @@ export const PageView = ({ className, vms, params }: PageViewProps) => {
         exportAsExcel={exportVmsAsExcel}
         allItems={hydratedItems}
         filteredItems={filteredItems}
+        onViewChange={setClientView}
       />
     </div>
   )

--- a/apps/web/src/app/(protected)/vms/page-view.tsx
+++ b/apps/web/src/app/(protected)/vms/page-view.tsx
@@ -43,7 +43,7 @@ import {
 import { NotReadyMessage } from '@/components/ui/not-ready-message'
 import { cn } from '@/utils/clsxm'
 import { SearchX } from 'lucide-react'
-import { useMemo, useCallback, useState } from 'react'
+import { useMemo, useCallback, useState, useEffect } from 'react'
 import { VMCard } from '@/features/vms/components/vm-card'
 import { VMCardData } from '@/features/vms/types/vm-types'
 import { displayDataOptions, sortingOptions } from '@/features/vms/config/page-view-options'
@@ -75,6 +75,19 @@ const isExpiredBackup = (expiryTime?: string | null) => {
 export const PageView = ({ className, vms, params }: PageViewProps) => {
   const filtersOpen = params.filterPanel === 'open'
   const [searchResetKey, setSearchResetKey] = useState(0)
+  const [clientView, setClientView] = useState<'grid' | 'list'>(params.view ?? 'grid')
+
+  // Sync when URL param changes (e.g. user clicks the toggle → router.push → params updates)
+  useEffect(() => {
+    setClientView(params.view ?? 'grid')
+  }, [params.view])
+
+  // On mount, override with localStorage when URL has no ?view
+  // (e.g. navigating back from another page — URL is bare /vms but localStorage says 'list')
+  useEffect(() => {
+    const stored = localStorage.getItem('vms:view-mode') as 'grid' | 'list' | null
+    if (stored) setClientView(stored)
+  }, [])
   const { items, sentinelRef, isLoading, hasMore } = useInfiniteLoader<VirtualMachine | VMWithBackupStatus>({
     initial: vms,
     sort: params.sort,
@@ -391,7 +404,7 @@ export const PageView = ({ className, vms, params }: PageViewProps) => {
         expect finished functionality or that all data is present. The development team is working hard on delivering a
         complete product as quick as possible :)
       </NotReadyMessage>
-      <section className='px-12 my-8'>{params.view === 'list' ? <TableView /> : <GridView />}</section>
+      <section className='px-12 my-8'>{clientView === 'list' ? <TableView /> : <GridView />}</section>
     </div>
   )
 }

--- a/apps/web/src/app/(protected)/vms/page-view.tsx
+++ b/apps/web/src/app/(protected)/vms/page-view.tsx
@@ -391,7 +391,9 @@ export const PageView = ({ className, vms, params }: PageViewProps) => {
         expect finished functionality or that all data is present. The development team is working hard on delivering a
         complete product as quick as possible :)
       </NotReadyMessage>
-      <section className='px-12 my-8'>{params.view === 'list' ? <TableView /> : <GridView />}</section>
+      <section className='px-12 my-8'>
+        {(searchParams.get('view') ?? params.view) === 'list' ? <TableView /> : <GridView />}
+      </section>
     </div>
   )
 }

--- a/apps/web/src/app/(protected)/vms/page-view.tsx
+++ b/apps/web/src/app/(protected)/vms/page-view.tsx
@@ -82,12 +82,14 @@ export const PageView = ({ className, vms, params }: PageViewProps) => {
     setClientView(params.view ?? 'grid')
   }, [params.view])
 
-  // On mount, override with localStorage when URL has no ?view
-  // (e.g. navigating back from another page — URL is bare /vms but localStorage says 'list')
+  // On mount (and when navigating to /vms without ?view), prefer localStorage.
+  // If URL contains ?view, keep URL as the source of truth.
   useEffect(() => {
-    const stored = localStorage.getItem('vms:view-mode') as 'grid' | 'list' | null
-    if (stored) setClientView(stored)
-  }, [])
+    if (params.view) return
+
+    const stored = localStorage.getItem('vms:view-mode')
+    if (stored === 'grid' || stored === 'list') setClientView(stored)
+  }, [params.view])
   const { items, sentinelRef, isLoading, hasMore } = useInfiniteLoader<VirtualMachine | VMWithBackupStatus>({
     initial: vms,
     sort: params.sort,

--- a/apps/web/src/app/(protected)/vms/page-view.tsx
+++ b/apps/web/src/app/(protected)/vms/page-view.tsx
@@ -43,7 +43,7 @@ import {
 import { NotReadyMessage } from '@/components/ui/not-ready-message'
 import { cn } from '@/utils/clsxm'
 import { SearchX } from 'lucide-react'
-import { useMemo, useCallback, useState, useEffect } from 'react'
+import { useMemo, useCallback, useState } from 'react'
 import { VMCard } from '@/features/vms/components/vm-card'
 import { VMCardData } from '@/features/vms/types/vm-types'
 import { displayDataOptions, sortingOptions } from '@/features/vms/config/page-view-options'
@@ -75,12 +75,6 @@ const isExpiredBackup = (expiryTime?: string | null) => {
 export const PageView = ({ className, vms, params }: PageViewProps) => {
   const filtersOpen = params.filterPanel === 'open'
   const [searchResetKey, setSearchResetKey] = useState(0)
-  const [viewMode, setViewMode] = useState<'grid' | 'list'>(params.view ?? 'grid')
-
-  useEffect(() => {
-    const stored = localStorage.getItem('vms:view-mode') as 'grid' | 'list' | null
-    if (stored) setViewMode(stored)
-  }, [])
   const { items, sentinelRef, isLoading, hasMore } = useInfiniteLoader<VirtualMachine | VMWithBackupStatus>({
     initial: vms,
     sort: params.sort,
@@ -397,10 +391,7 @@ export const PageView = ({ className, vms, params }: PageViewProps) => {
         expect finished functionality or that all data is present. The development team is working hard on delivering a
         complete product as quick as possible :)
       </NotReadyMessage>
-      <section className='px-12 my-8'>
-        {/* {(searchParams.get('view') ?? params.view) === 'list' ? <TableView /> : <GridView />} */}
-        {viewMode === 'list' ? <TableView /> : <GridView />}
-      </section>
+      <section className='px-12 my-8'>{params.view === 'list' ? <TableView /> : <GridView />}</section>
     </div>
   )
 }

--- a/apps/web/src/app/(protected)/vms/page-view.tsx
+++ b/apps/web/src/app/(protected)/vms/page-view.tsx
@@ -43,7 +43,7 @@ import {
 import { NotReadyMessage } from '@/components/ui/not-ready-message'
 import { cn } from '@/utils/clsxm'
 import { SearchX } from 'lucide-react'
-import { useMemo, useCallback, useState } from 'react'
+import { useMemo, useCallback, useState, useEffect } from 'react'
 import { VMCard } from '@/features/vms/components/vm-card'
 import { VMCardData } from '@/features/vms/types/vm-types'
 import { displayDataOptions, sortingOptions } from '@/features/vms/config/page-view-options'
@@ -75,6 +75,12 @@ const isExpiredBackup = (expiryTime?: string | null) => {
 export const PageView = ({ className, vms, params }: PageViewProps) => {
   const filtersOpen = params.filterPanel === 'open'
   const [searchResetKey, setSearchResetKey] = useState(0)
+  const [viewMode, setViewMode] = useState<'grid' | 'list'>(params.view ?? 'grid')
+
+  useEffect(() => {
+    const stored = localStorage.getItem('vms:view-mode') as 'grid' | 'list' | null
+    if (stored) setViewMode(stored)
+  }, [])
   const { items, sentinelRef, isLoading, hasMore } = useInfiniteLoader<VirtualMachine | VMWithBackupStatus>({
     initial: vms,
     sort: params.sort,
@@ -392,7 +398,8 @@ export const PageView = ({ className, vms, params }: PageViewProps) => {
         complete product as quick as possible :)
       </NotReadyMessage>
       <section className='px-12 my-8'>
-        {(searchParams.get('view') ?? params.view) === 'list' ? <TableView /> : <GridView />}
+        {/* {(searchParams.get('view') ?? params.view) === 'list' ? <TableView /> : <GridView />} */}
+        {viewMode === 'list' ? <TableView /> : <GridView />}
       </section>
     </div>
   )

--- a/apps/web/src/components/ui/resource-controls.tsx
+++ b/apps/web/src/components/ui/resource-controls.tsx
@@ -72,6 +72,7 @@ interface ResourceControlsProps<T> {
   filteredItems: T[]
   allItems: T[]
   searchResetKey?: number
+  onViewChange?: (view: 'grid' | 'list') => void
 }
 
 /**
@@ -124,6 +125,7 @@ export function ResourceControls<T>({
   filteredItems,
   allItems,
   searchResetKey,
+  onViewChange,
 }: ResourceControlsProps<T>) {
   return (
     <div className='flex flex-wrap items-center justify-between w-full gap-4 [@container(max-width:1000px)]:flex-col [@container(max-width:1000px)]:items-start [@container(max-width:1000px)]:gap-6'>
@@ -268,7 +270,7 @@ export function ResourceControls<T>({
           </DropdownMenuContent>
         </DropdownMenu>
 
-        <TabsViewSwitcher storageKey={`${domain}:view-mode`} />
+        <TabsViewSwitcher storageKey={`${domain}:view-mode`} onViewChange={onViewChange} />
       </div>
     </div>
   )

--- a/apps/web/src/components/ui/tabs-view-switcher.tsx
+++ b/apps/web/src/components/ui/tabs-view-switcher.tsx
@@ -36,7 +36,12 @@ export function TabsViewSwitcher({ storageKey }: TabsViewSwitcherProps = {}) {
     setSelected(view)
     setMounted(true)
 
-    // If view doesn't match URL, update the URL to reflect current state
+    // Only update URL if it doesn't already reflect the desired view.
+    // Without this guard, every router.replace triggers a searchParams change
+    // which re-runs this effect, causing a loop that breaks in production.
+    const expectedParam = view === 'grid' ? null : view
+    if (fromUrl === expectedParam) return
+
     const params = new URLSearchParams(searchParams)
     if (view === 'grid') {
       params.delete('view')
@@ -44,8 +49,7 @@ export function TabsViewSwitcher({ storageKey }: TabsViewSwitcherProps = {}) {
       params.set('view', view)
     }
 
-    // Use current pathname instead of hardcoded route
-    router.replace(params.size === 0 ? pathname : `${pathname}?${params.toString()}`)
+    router.replace(params.size === 0 ? pathname : `${pathname}?${params.toString()}`, { scroll: false })
   }, [searchParams, router, pathname, LOCAL_STORAGE_KEY])
 
   const handleChange = (value: string) => {

--- a/apps/web/src/components/ui/tabs-view-switcher.tsx
+++ b/apps/web/src/components/ui/tabs-view-switcher.tsx
@@ -7,9 +7,10 @@ import { useEffect, useState } from 'react'
 
 interface TabsViewSwitcherProps {
   storageKey?: string
+  onViewChange?: (view: 'grid' | 'list') => void
 }
 
-export function TabsViewSwitcher({ storageKey }: TabsViewSwitcherProps = {}) {
+export function TabsViewSwitcher({ storageKey, onViewChange }: TabsViewSwitcherProps = {}) {
   const router = useRouter()
   const searchParams = useSearchParams()
   const pathname = usePathname()
@@ -64,7 +65,7 @@ export function TabsViewSwitcher({ storageKey }: TabsViewSwitcherProps = {}) {
     }
 
     localStorage.setItem(LOCAL_STORAGE_KEY, value)
-    // Use current pathname instead of hardcoded route
+    onViewChange?.(value as 'grid' | 'list')
     router.push(params.size === 0 ? pathname : `${pathname}?${params.toString()}`)
     setSelected(value)
   }


### PR DESCRIPTION
The suspense added on the VMs page messed up the view-mode param.

Now I have added a clientState on the view-state, that renders with the page-view. 
The tabs-switch is also changed by adding an optional onViewChange that is necessary on the vm-page.
This can also be used on the cluster-page if it ever is added a suspense on the cluster-page as well for faster redirect.
