### PR TITLE
Changed to uid instead of name on redirect (href)

### DIFF
--- a/apps/web/src/app/(protected)/my-dashboard/page-view.tsx
+++ b/apps/web/src/app/(protected)/my-dashboard/page-view.tsx
@@ -72,10 +72,10 @@ export const PageView = ({ overviewItems }: PageViewProps) => {
         domain='vms'
         itemId={getVmUid(vm)}
         onUnfavorite={fetchFavorites}
-        onClick={() => {
-          router.push(routes.app.vm.getHref(getVmUid(vm)))
-          localStorage.setItem('selectedVm', JSON.stringify(vm))
-        }}
+onClick={() => {
+  localStorage.setItem('selectedVm', JSON.stringify(vm))
+  router.push(routes.app.vm.getHref(getVmUid(vm)))
+}}
       >
         <FavoritedVm vm={vm} />
       </FavoritedBox>

--- a/apps/web/src/app/(protected)/my-dashboard/page-view.tsx
+++ b/apps/web/src/app/(protected)/my-dashboard/page-view.tsx
@@ -10,7 +10,7 @@ import { ClusterListViewItemRowType, OverviewItemsViewRowType, VirtualMachine } 
 import { useCallback, useEffect, useState } from 'react'
 import { loadFavoritedClusters, loadFavoritedVms } from '@/features/dashboard/utils/favorited-item'
 import { FavoritedVm, FavoritedVmRow } from '@/features/dashboard/components/favorited-vm'
-import { getVmUid, getVmName } from '@/features/vms/utils/vms'
+import { getVmUid } from '@/features/vms/utils/vms'
 import { LayoutGrid, LayoutList } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/shadcn/tooltip'
 import { DashboardSearch } from '@/features/dashboard/components/dashboard-search'
@@ -72,7 +72,10 @@ export const PageView = ({ overviewItems }: PageViewProps) => {
         domain='vms'
         itemId={getVmUid(vm)}
         onUnfavorite={fetchFavorites}
-        onClick={() => router.push(routes.app.vm.getHref(getVmName(vm).toLowerCase()))}
+        onClick={() => {
+          router.push(routes.app.vm.getHref(getVmUid(vm)))
+          localStorage.setItem('selectedVm', JSON.stringify(vm))
+        }}
       >
         <FavoritedVm vm={vm} />
       </FavoritedBox>

--- a/apps/web/src/features/dashboard/components/favorited-vm.tsx
+++ b/apps/web/src/features/dashboard/components/favorited-vm.tsx
@@ -63,7 +63,10 @@ export const FavoritedVmRow = ({ vm, onUnfavorite }: { vm: VirtualMachine; onUnf
 
   return (
     <div
-      onClick={() => router.push(routes.app.vm.getHref(getVmName(vm).toLowerCase()))}
+      onClick={() => {
+        router.push(routes.app.vm.getHref(getVmUid(vm)))
+        localStorage.setItem('selectedVm', JSON.stringify(vm))
+      }}
       className={cn(
         'flex items-center gap-3 px-3 py-2 bg-(--r-layer) rounded-md transition-opacity cursor-pointer',
         isPoweredOff && 'opacity-50'

--- a/apps/web/src/features/dashboard/components/favorited-vm.tsx
+++ b/apps/web/src/features/dashboard/components/favorited-vm.tsx
@@ -63,10 +63,10 @@ export const FavoritedVmRow = ({ vm, onUnfavorite }: { vm: VirtualMachine; onUnf
 
   return (
     <div
-      onClick={() => {
-        router.push(routes.app.vm.getHref(getVmUid(vm)))
-        localStorage.setItem('selectedVm', JSON.stringify(vm))
-      }}
+onClick={() => {
+  localStorage.setItem('selectedVm', JSON.stringify(vm))
+  router.push(routes.app.vm.getHref(getVmUid(vm)))
+}}
       className={cn(
         'flex items-center gap-3 px-3 py-2 bg-(--r-layer) rounded-md transition-opacity cursor-pointer',
         isPoweredOff && 'opacity-50'

--- a/apps/web/src/features/vms/components/vm-card.tsx
+++ b/apps/web/src/features/vms/components/vm-card.tsx
@@ -211,10 +211,7 @@ const VMCard = ({ className, vm, vmDisplayData }: VMCardProps) => {
   }
 
   return (
-    <Link
-      href={routes.app.vm.getHref(name?.toLowerCase())}
-      onClick={() => localStorage.setItem('selectedVm', JSON.stringify(vm))}
-    >
+    <Link href={routes.app.vm.getHref(vmUid)} onClick={() => localStorage.setItem('selectedVm', JSON.stringify(vm))}>
       <Card
         className={cn(
           'group w-sm min-w-64 pt-0 hover:bg-[#ededed] dark:hover:bg-neutral-800 hover:cursor-pointer @vm vm',

--- a/apps/web/src/features/vms/components/vm-columns.tsx
+++ b/apps/web/src/features/vms/components/vm-columns.tsx
@@ -23,6 +23,7 @@ import {
   getVmToolVersion,
   getVmVersion,
   getVmFamily,
+  getVmUid,
 } from '../utils/vms'
 import { changePowerStateValues } from '../types/powerState'
 import { PowerStatusIcon } from './power-status-icon'
@@ -56,10 +57,10 @@ export const getVMTableColumns = (selectedDisplayData?: VMColumnsData[]): DataTa
       cell: (info) => {
         const name = String(info.getValue() ?? '')
         const vm = info.row.original
-        const vmName = getVmName(vm) || ''
+        const vmUid = getVmUid(vm)
         return (
           <Link
-            href={routes.app.vm.getHref(vmName.toLowerCase())}
+            href={routes.app.vm.getHref(vmUid)}
             className='pr-2 text-blue-600 dark:text-blue-500 underline break-all'
             onClick={() => localStorage.setItem('selectedVm', JSON.stringify(vm))}
           >


### PR DESCRIPTION
The url now sets the href of the selected vm to the uid (not name).
Also added localstorage setItem("selectedVm") on the dashboard favritedItem to fix the redirect to the individual page. 